### PR TITLE
[ Hotfix ] 헤더, 페이지 레이아웃 수정

### DIFF
--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -7,53 +7,44 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   const nickname = sessionStorage.getItem('nickname');
   const isLogin = nickname && nickname.length > 0;
   return (
-    <HeaderWrapper>
-      <HeaderContainer>
-        <LogoContainer>
-          <IcLogo />
-        </LogoContainer>
-        <NavBarContainer>
-          <NavBarUl>
-            {DATA.map((v) => {
-              return (
-                <NavBar key={v.text}>
-                  {isLogin && clickedCategory === v.text && (
-                    <IconContainer>{v.icon}</IconContainer>
-                  )}
-                  <Text
-                    onClick={(e) => isLogin && handleClickCategory(e)}
-                    $isClickedCategory={clickedCategory === v.text}
-                  >
-                    {v.text}
-                  </Text>
-                </NavBar>
-              );
-            })}
-          </NavBarUl>
-        </NavBarContainer>
-        <LoginBtnContainer $isLogin={isLogin ? true : false}>
-          <IcLoginIcon />
-          <LoginBtn>{isLogin ? `${nickname} 님` : '로그인'}</LoginBtn>
-        </LoginBtnContainer>
-      </HeaderContainer>
-    </HeaderWrapper>
+    <HeaderContainer>
+      <LogoContainer>
+        <IcLogo />
+      </LogoContainer>
+      <NavBarContainer>
+        <NavBarUl>
+          {DATA.map((v) => {
+            return (
+              <NavBar key={v.text}>
+                {isLogin && clickedCategory === v.text && (
+                  <IconContainer>{v.icon}</IconContainer>
+                )}
+                <Text
+                  onClick={(e) => isLogin && handleClickCategory(e)}
+                  $isClickedCategory={clickedCategory === v.text}
+                >
+                  {v.text}
+                </Text>
+              </NavBar>
+            );
+          })}
+        </NavBarUl>
+      </NavBarContainer>
+      <LoginBtnContainer $isLogin={isLogin ? true : false}>
+        <IcLoginIcon />
+        <LoginBtn>{isLogin ? `${nickname} 님` : '로그인'}</LoginBtn>
+      </LoginBtnContainer>
+    </HeaderContainer>
   );
 };
 
 export default Header;
-
-const HeaderWrapper = styled.header`
-  display: flex;
-
-  width: 100%;
-`;
 
 const HeaderContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
 
-  width: 100%;
   padding-top: 4.9rem;
   padding-bottom: 1.2rem;
   margin: 0 23.9rem;
@@ -96,8 +87,10 @@ const Text = styled.p<{ $isClickedCategory: boolean }>`
 
 const LoginBtnContainer = styled.div<{ $isLogin: boolean }>`
   display: flex;
+  justify-content: end;
 
-  margin-left: ${({ $isLogin }) => ($isLogin ? '46.2rem' : '50.6rem')};
+  width: 23.2rem;
+  margin-left: ${({ $isLogin }) => ($isLogin ? '29.7rem' : '34.1rem')};
 `;
 
 const LoginBtn = styled.button`

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -29,5 +29,6 @@ export default PageLayout;
 const PageLayoutContainer = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-direction: column;
 `;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #46 

## ✅ 작업 내용

- [x] 페이지 레이아웃 수정
- [x] 닉네임 글자 수에 따라 헤더 크기가 변하는 이슈 해결

## 📸 스크린샷 / GIF / Link

### 글자 수: 2

![스크린샷 2024-07-25 오후 4 58 21](https://github.com/user-attachments/assets/d2bf2e51-a9de-4ed2-83c8-1b0d4de69e3d)

### 글자 수: 10

![스크린샷 2024-07-25 오후 4 58 39](https://github.com/user-attachments/assets/5eb990a6-63d3-4d53-9385-c83ed7672847)

### 화면 크기 늘려봤을 때

![스크린샷 2024-07-25 오후 4 59 31](https://github.com/user-attachments/assets/3c7ec5a5-440c-4f7f-9a11-70d45e9d23d8)

## 📌 이슈 사항
### 1️⃣ PageLayout
- `align-items: center` 추가
- 피그마 상의 뷰들 모두 가로 중앙 정렬이라 요거 추가했습니당
- 특히 얘를 적용했을 때 컴포넌트 설계가 달라지는 것들이 있을 거라서 hotfix로 브랜치 팠습니당

### 2️⃣ Header
- 닉네임 들어가는 영역을 피그마와 동일하게 잡고, 오른쪽 정렬했습니당
