### PR TITLE
[ Solve/ Solution ] 풀었던 문제 다시보기(본인) 뷰 퍼블리싱

### DIFF
--- a/src/assets/icon/ic_link_purple.svg
+++ b/src/assets/icon/ic_link_purple.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 9.99983L10 14" stroke="#BF57FF" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M17 12.8824L19.0588 10.8235C20.6832 9.19916 20.6832 6.56554 19.0588 4.94118V4.94118C17.4345 3.31681 14.8008 3.31681 13.1765 4.94118L11.1176 7M7 11.1176L4.94118 13.1765C3.31681 14.8008 3.31681 17.4345 4.94118 19.0588V19.0588C6.56554 20.6832 9.19916 20.6832 10.8235 19.0588L12.8824 17" stroke="#BF57FF" stroke-width="1.5" stroke-linecap="square"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -18,9 +18,10 @@ import IcCancelSmall from './icon/ic_cancel_small.svg?react';
 import IcCode from './icon/ic_code.svg?react';
 import IcGroup from './icon/ic_group.svg?react';
 import IcHome from './icon/ic_home.svg?react';
-import IcLoginIcon from './icon/ic_login_Icon.svg?react';
 import IcInformation from './icon/ic_information.svg?react';
 import IcLinkGray from './icon/ic_link_gray.svg?react';
+import IcLinkPurple from './icon/ic_link_purple.svg?react';
+import IcLoginIcon from './icon/ic_login_Icon.svg?react';
 import IcLogo from './icon/ic_logo.svg?react';
 import IcMemoWhite from './icon/ic_memo_white.svg?react';
 import IcSecretBigWhite from './icon/ic_secret_big_white.svg?react';
@@ -53,9 +54,10 @@ export {
   IcCode,
   IcGroup,
   IcHome,
-  IcLoginIcon,
   IcInformation,
   IcLinkGray,
+  IcLinkPurple,
+  IcLoginIcon,
   IcLogo,
   IcMemoWhite,
   IcSecretBigWhite,

--- a/src/common/CodeSpace/CodeEditor.tsx
+++ b/src/common/CodeSpace/CodeEditor.tsx
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 import { LANG_LIST } from '../../constants/CodeEditor/language';
 import { CodeEditorProps } from '../../types/Solve/solveTypes';
 
-const CodeEditor = ({ stringId, code, handleChangeCode }: CodeEditorProps) => {
+const CodeEditor = ({
+  isReadOnly,
+  stringId,
+  code,
+  handleChangeCode,
+}: CodeEditorProps) => {
   const LANGUAGE = sessionStorage.getItem('language') as keyof typeof LANG_LIST;
   if (!LANGUAGE) {
     // 추후 주 언어를 선택해달라는 문구 + 마이페이지로 네비게이트 시키기

--- a/src/common/CodeSpace/CodeEditor.tsx
+++ b/src/common/CodeSpace/CodeEditor.tsx
@@ -33,7 +33,12 @@ const CodeEditor = ({
       <CodeMirror
         id={stringId}
         value={code}
-        onChange={(newCode) => handleChangeCode({ newCode, stringId })}
+        readOnly={isReadOnly}
+        editable={!isReadOnly}
+        onChange={(newCode) => {
+          if (!isReadOnly && handleChangeCode)
+            handleChangeCode({ newCode, stringId });
+        }}
         extensions={extensions}
         theme={dracula}
         height="38.2rem"

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -43,6 +43,8 @@ export default Memo;
 
 const MemoContainer = styled.article`
   width: 100%;
+  min-width: 92.6rem;
+
   padding: 2.4rem 2.6rem 0 2.4rem;
 
   border-radius: 0.8rem;

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -30,7 +30,9 @@ const Memo = ({ isReadOnly, stringId, memo, handleChangeMemo }: MemoProps) => {
           id={stringId}
           name="memo"
           value={memo}
-          onChange={handleChangeMemo}
+          onChange={(e) => {
+            if (!isReadOnly && handleChangeMemo) handleChangeMemo(e);
+          }}
         />
       </TextareaContainer>
     </MemoContainer>

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { IcArrowBottomGray, IcArrowTopGray, IcMemoWhite } from '../../assets';
 import { MemoProps } from '../../types/Solve/solveTypes';
 
-const Memo = ({ stringId, memo, handleChangeMemo }: MemoProps) => {
+const Memo = ({ isReadOnly, stringId, memo, handleChangeMemo }: MemoProps) => {
   const [isMemoOpen, setIsMemoOpen] = useState(false);
 
   const handleclickArrow = () => {

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -11,18 +11,14 @@ const Memo = ({ isReadOnly, stringId, memo, handleChangeMemo }: MemoProps) => {
   };
 
   return (
-    <MemoContainer>
+    <MemoContainer onClick={handleclickArrow}>
       <TopBar>
         <TitleContainer>
           <IcMemoWhite />
           <Title>메모장</Title>
         </TitleContainer>
 
-        {isMemoOpen ? (
-          <IcArrowTopGray onClick={handleclickArrow} />
-        ) : (
-          <IcArrowBottomGray onClick={handleclickArrow} />
-        )}
+        {isMemoOpen ? <IcArrowTopGray /> : <IcArrowBottomGray />}
       </TopBar>
 
       <TextareaContainer $isMemoOpen={isMemoOpen}>

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -26,6 +26,7 @@ const Memo = ({ isReadOnly, stringId, memo, handleChangeMemo }: MemoProps) => {
           id={stringId}
           name="memo"
           value={memo}
+          readOnly={isReadOnly}
           onChange={(e) => {
             if (!isReadOnly && handleChangeMemo) handleChangeMemo(e);
           }}

--- a/src/common/CodeSpace/Memo.tsx
+++ b/src/common/CodeSpace/Memo.tsx
@@ -11,8 +11,8 @@ const Memo = ({ isReadOnly, stringId, memo, handleChangeMemo }: MemoProps) => {
   };
 
   return (
-    <MemoContainer onClick={handleclickArrow}>
-      <TopBar>
+    <MemoContainer>
+      <TopBar onClick={handleclickArrow}>
         <TitleContainer>
           <IcMemoWhite />
           <Title>메모장</Title>

--- a/src/components/Solution/Header/SolutionHeaderBottom.tsx
+++ b/src/components/Solution/Header/SolutionHeaderBottom.tsx
@@ -32,6 +32,7 @@ const HeaderBottomContainer = styled.ul`
   justify-content: center;
 
   width: 100%;
+  margin-bottom: 2.2rem;
 `;
 
 const CommonTagStyle = styled.li`
@@ -48,9 +49,9 @@ const CommonTagStyle = styled.li`
 const Tag = styled(CommonTagStyle)`
   flex-grow: 2.8;
 
-  min-width: 39.4rem;
+  min-width: 34.9rem;
 
-  padding: 1.5rem 1.2rem 1.4rem 2rem;
+  padding: 1.5rem 0 1.4rem;
 `;
 
 const Platform = styled(CommonTagStyle)`
@@ -58,7 +59,7 @@ const Platform = styled(CommonTagStyle)`
 
   min-width: 12.4rem;
 
-  padding: 1.5rem 2rem 1.4rem;
+  padding: 1.5rem 0 1.4rem;
 `;
 
 const LinkContainer = styled(CommonTagStyle)`
@@ -66,7 +67,7 @@ const LinkContainer = styled(CommonTagStyle)`
 
   min-width: 41.7rem;
 
-  padding: 1.2rem 2rem 1.2rem 1.4rem;
+  padding: 1.2rem 0;
 `;
 
 const Link = styled.p`

--- a/src/components/Solution/Header/SolutionHeaderBottom.tsx
+++ b/src/components/Solution/Header/SolutionHeaderBottom.tsx
@@ -1,0 +1,82 @@
+import styled from 'styled-components';
+import { IcLinkPurple } from '../../../assets';
+
+export interface SolutionHeaderBottomProps {
+  tags: Array<string>;
+  platform: string;
+  problemUrl: string;
+}
+
+const SolutionHeaderBottom = ({
+  tags,
+  platform,
+  problemUrl,
+}: SolutionHeaderBottomProps) => {
+  return (
+    <HeaderBottomContainer>
+      <Tag>{tags.join(', ')}</Tag>
+      <Platform>{platform}</Platform>
+      <LinkContainer>
+        <IcLinkPurple />
+        <Link>{problemUrl}</Link>
+      </LinkContainer>
+    </HeaderBottomContainer>
+  );
+};
+
+export default SolutionHeaderBottom;
+
+const HeaderBottomContainer = styled.ul`
+  display: flex;
+  gap: 1.8rem;
+  justify-content: center;
+
+  width: 100%;
+`;
+
+const CommonTagStyle = styled.li`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme }) => theme.colors.gray800};
+  color: ${({ theme }) => theme.colors.codrive_purple};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Tag = styled(CommonTagStyle)`
+  flex-grow: 2.8;
+
+  min-width: 39.4rem;
+
+  padding: 1.5rem 1.2rem 1.4rem 2rem;
+`;
+
+const Platform = styled(CommonTagStyle)`
+  flex-grow: 1;
+
+  min-width: 12.4rem;
+
+  padding: 1.5rem 2rem 1.4rem;
+`;
+
+const LinkContainer = styled(CommonTagStyle)`
+  flex-grow: 3.4;
+
+  min-width: 41.7rem;
+
+  padding: 1.2rem 2rem 1.2rem 1.4rem;
+`;
+
+const Link = styled.p`
+  width: 35.1rem;
+  margin-left: 0.8rem;
+
+  color: ${({ theme }) => theme.colors.codrive_purple};
+  ${({ theme }) => theme.fonts.title_bold_16};
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+`;

--- a/src/components/Solution/Header/SolutionHeaderTop.tsx
+++ b/src/components/Solution/Header/SolutionHeaderTop.tsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+import { IcInformation, IcStarGray, IcStarGreen } from '../../../assets';
+
+export interface SolutionHeaderTopProps {
+  title: string;
+  date: string;
+  paintedStarArr: Array<number>;
+}
+
+const SolutionHeaderTop = ({
+  title,
+  date,
+  paintedStarArr,
+}: SolutionHeaderTopProps) => {
+  return (
+    <SolutionHeaderTopContainer>
+      <TitleContainer>
+        <Title>{title}</Title>
+        <Date>{`작성일자 | ${date}`}</Date>
+      </TitleContainer>
+
+      <LevelContainer>
+        <LevelDetailContainer>
+          <LvText>난이도</LvText>
+          <LvText>|</LvText>
+          <LvStarContainer>
+            {paintedStarArr.map((painted, idx) => {
+              return (
+                <li key={idx}>{painted ? <IcStarGreen /> : <IcStarGray />}</li>
+              );
+            })}
+          </LvStarContainer>
+        </LevelDetailContainer>
+
+        <IcInformation />
+      </LevelContainer>
+    </SolutionHeaderTopContainer>
+  );
+};
+
+export default SolutionHeaderTop;
+
+const SolutionHeaderTopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+  gap: 2.7rem;
+  flex-direction: column;
+`;
+
+const Title = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_24};
+`;
+
+const Date = styled.p`
+  color: ${({ theme }) => theme.colors.gray200};
+  ${({ theme }) => theme.fonts.body_medium_14};
+`;
+
+const LevelContainer = styled.div`
+  display: flex;
+  gap: 7.4rem;
+  justify-content: center;
+  align-items: center;
+
+  margin: 9.1rem 0 3rem;
+`;
+
+const LevelDetailContainer = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LvText = styled.p`
+  ${({ theme }) => theme.fonts.title_bold_16};
+  color: ${({ theme }) => theme.colors.gray300};
+`;
+
+const LvStarContainer = styled.ul`
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Solve/CodeSpace.tsx
+++ b/src/components/Solve/CodeSpace.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
 import { IcCancelFill, IcCode } from '../../assets';
 import { CodeSpaceProps } from '../../types/Solve/solveTypes';
-import CodeEditor from './CodeEditor';
+
+import CodeEditor from '../../common/CodeSpace/CodeEditor';
+import Memo from '../../common/CodeSpace/Memo';
 import CodeSpaceHeader from './Header/CodeSpaceHeader';
-import Memo from './Memo';
 
 const CodeSpace = ({
   ideItems,
@@ -33,12 +34,14 @@ const CodeSpace = ({
             </TopBar>
 
             <CodeEditor
+              isReadOnly={false}
               stringId={item.id.toString()}
               code={item.code}
               handleChangeCode={handleChangeCode}
             />
 
             <Memo
+              isReadOnly={false}
               stringId={item.id.toString()}
               memo={item.memo}
               handleChangeMemo={handleChangeMemo}

--- a/src/page/SolutionPage.tsx
+++ b/src/page/SolutionPage.tsx
@@ -1,4 +1,7 @@
+import React from 'react';
 import styled from 'styled-components';
+import CodeEditor from '../common/CodeSpace/CodeEditor';
+import Memo from '../common/CodeSpace/Memo';
 import PageLayout from '../components/PageLayout/PageLayout';
 import SolutionHeaderBottom from '../components/Solution/Header/SolutionHeaderBottom';
 import SolutionHeaderTop from '../components/Solution/Header/SolutionHeaderTop';
@@ -17,7 +20,7 @@ const DUMMY = [
         memo: 'from django.contrib.auth import views as auth_views를 추가해야 Django auth에 내장되어 있는 LoginView, LogoutView를 사용할 수 있다. 따라서 앱 폴더의 views.py에서 따로 코드를 작성할 필요가 없다.\n\nas auth_views로 alias(별칭)을 주는 이유는 앱 폴더 내에 있는 views.py와 충돌하지 않도록 다른 이름을 사용한 것이다.',
       },
       {
-        code: '// code',
+        code: '// 프로세스\nfunction solution(priorities, location) {\n  var cnt = 0;\n  const obj = priorities.map((prio, idx) => {\n    return { prio, idx };\n  });\n\n  while (obj.length) {\n    const MAX = Math.max(...priorities);\n\n    const process = obj.shift();\n    const prio = priorities.shift();\n    if (process.prio < MAX) {\n      obj.push(process);\n      priorities.push(prio);\n    } else {\n      cnt++;\n      if (process.idx === location) {\n        return cnt;\n      }\n    }\n  }\n\n  return cnt;\n}\n\nconsole.log(solution([2, 1, 3, 2], 2));\nconsole.log(solution([1, 1, 9, 1, 1, 1], 0));\n',
         memo: '',
       },
     ],
@@ -36,23 +39,41 @@ const SolutionPage = () => {
             .concat(Array(5 - level).fill(0));
 
           return (
-            <SolutionPageHeader key={title}>
-              <SolutionHeaderTop
-                title={title}
-                date={date}
-                paintedStarArr={paintedStarArr}
-              />
+            <React.Fragment key={title}>
+              <SolutionPageHeader>
+                <SolutionHeaderTop
+                  title={title}
+                  date={date}
+                  paintedStarArr={paintedStarArr}
+                />
 
-              <SolutionHeaderBottom
-                tags={tags}
-                platform={platform}
-                problemUrl={problemUrl}
-              />
-            </SolutionPageHeader>
+                <SolutionHeaderBottom
+                  tags={tags}
+                  platform={platform}
+                  problemUrl={problemUrl}
+                />
+              </SolutionPageHeader>
+
+              {codeblocks.map((codeblock, idx) => {
+                const { code, memo } = codeblock;
+                return (
+                  <CodeBlckContainer key={idx}>
+                    <CodeEditor
+                      isReadOnly={true}
+                      stringId={idx.toString()}
+                      code={code}
+                    />
+                    <Memo
+                      isReadOnly={true}
+                      stringId={idx.toString()}
+                      memo={memo}
+                    />
+                  </CodeBlckContainer>
+                );
+              })}
+            </React.Fragment>
           );
         })}
-        {/* <CodeEditor />
-        <Memo /> */}
       </SolutionPageContainer>
     </PageLayout>
   );
@@ -76,4 +97,12 @@ const SolutionPageHeader = styled.header`
   flex-direction: column;
 
   width: 100%;
+`;
+
+const CodeBlckContainer = styled.article`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  margin-bottom: 3.6rem;
 `;

--- a/src/page/SolutionPage.tsx
+++ b/src/page/SolutionPage.tsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import PageLayout from '../components/PageLayout/PageLayout';
+import SolutionHeaderBottom from '../components/Solution/Header/SolutionHeaderBottom';
+import SolutionHeaderTop from '../components/Solution/Header/SolutionHeaderTop';
+
+const DUMMY = [
+  {
+    title: '전생했더니 슬라임 연구자가 아니었던 건에 대하여',
+    date: '2024.07.23',
+    level: 3,
+    tags: ['스택/큐', '동적계획법 (Dynamic Programming)'],
+    platform: '프로그래머스',
+    problemUrl: 'https://roseline124.github.io/djdefagrssd.dfdsdfds',
+    codeblocks: [
+      {
+        code: 'from django.contrib.auth import views as auth_views를 추가해야 Django auth에 내장되어 있는 LoginView, LogoutView를 사용할 수 있다. 따라서 앱 폴더의 views.py에서 따로 코드를 작성할 필요가 없다.\n\nas auth_views로 alias(별칭)을 주는 이유는 앱 폴더 내에 있는 views.py와 충돌하지 않도록 다른 이름을 사용한 것이다.',
+        memo: 'from django.contrib.auth import views as auth_views를 추가해야 Django auth에 내장되어 있는 LoginView, LogoutView를 사용할 수 있다. 따라서 앱 폴더의 views.py에서 따로 코드를 작성할 필요가 없다.\n\nas auth_views로 alias(별칭)을 주는 이유는 앱 폴더 내에 있는 views.py와 충돌하지 않도록 다른 이름을 사용한 것이다.',
+      },
+      {
+        code: '// code',
+        memo: '',
+      },
+    ],
+  },
+];
+
+const SolutionPage = () => {
+  return (
+    <PageLayout category="문제풀이">
+      <SolutionPageContainer>
+        {DUMMY.map((data) => {
+          const { title, date, level, tags, platform, problemUrl, codeblocks } =
+            data;
+          const paintedStarArr: Array<number> = Array(level)
+            .fill(1)
+            .concat(Array(5 - level).fill(0));
+
+          return (
+            <SolutionPageHeader key={title}>
+              <SolutionHeaderTop
+                title={title}
+                date={date}
+                paintedStarArr={paintedStarArr}
+              />
+
+              <SolutionHeaderBottom
+                tags={tags}
+                platform={platform}
+                problemUrl={problemUrl}
+              />
+            </SolutionPageHeader>
+          );
+        })}
+        {/* <CodeEditor />
+        <Memo /> */}
+      </SolutionPageContainer>
+    </PageLayout>
+  );
+};
+
+export default SolutionPage;
+
+const SolutionPageContainer = styled.section`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+  padding: 6.4rem 25.7rem 20rem;
+`;
+
+const SolutionPageHeader = styled.header`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+`;

--- a/src/types/Solve/solveTypes.ts
+++ b/src/types/Solve/solveTypes.ts
@@ -26,11 +26,13 @@ interface clickQuestionInfoFnProps {
 }
 
 export interface CodeEditorProps extends changeCodeFnProps {
+  isReadOnly: boolean;
   stringId: string;
   code: string;
 }
 
 export interface MemoProps extends changeMemoFnProps {
+  isReadOnly: boolean;
   stringId: string;
   memo: string;
 }

--- a/src/types/Solve/solveTypes.ts
+++ b/src/types/Solve/solveTypes.ts
@@ -25,16 +25,18 @@ interface clickQuestionInfoFnProps {
   }: handleClickQuestionInfoProps) => void;
 }
 
-export interface CodeEditorProps extends changeCodeFnProps {
+export interface CodeEditorProps {
   isReadOnly: boolean;
   stringId: string;
   code: string;
+  handleChangeCode?: ({ newCode, stringId }: handleChangeCodeProps) => void;
 }
 
-export interface MemoProps extends changeMemoFnProps {
+export interface MemoProps {
   isReadOnly: boolean;
   stringId: string;
   memo: string;
+  handleChangeMemo?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export interface HeaderTopProps extends clickQuestionInfoFnProps {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #12 

## ✅ 작업 내용

- [x] 코드 에디터/ 메모 컴포넌트를 공통 컴포넌트로 변경
- [x] 코드 에디터/ 메모를 readOnly로 띄울 수 있도록 코드 수정
- [x] 풀었던 문제 다시보기(본인) 뷰 퍼블리싱

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/cf092c04-192c-427a-a061-2024409cb314


## 📌 이슈 사항
### 0️⃣ 브랜치 분기
- 원래는 feat/solution 브랜치를 하나 파려구 했는데 feat/solve 브랜치에서 작업한 컴포넌트들을 활용하기 위해서 feat/solve 브랜치에서 분기했습니당
   - feat/solve에서 작업한 내용의 코드리뷰가 아직 마무리되지 않아서 상위 브랜치로 따로 머지하지 않고 feat/solve 브랜치 그대로 사용했습니다!

<br />

### 1️⃣ 코드 에디터/ 메모 컴포넌트를 공통 컴포넌트로 변경
- 코드 에디터/ 메모 컴포넌트는 원래 문제 풀이 등록 뷰에서 정의/ 사용하던 컴포넌트였는데, 이번 뷰를 구현하려고 보니까 코드/ 메모 부분이 동일하게 들어가더라구요!
- 그래서 공통 컴포넌트로 변경해서 Solution 컴포넌트에서도 사용했습니다 !

<br />

### 2️⃣ 코드 에디터/ 메모를 readOnly로 띄울 수 있도록 코드 수정
- Solution에서는 해당 컴포넌트들을 readOnly로 띄워줘야 했어요 !
- isReadOnly라는 props를 추가해서 읽기 모드/ 편집 모드로 나뉘도록 분기처리했습니다.
- 이때 onChange 함수는 편집 모드에서만 유효한 함수이기 때문에, nullable로 타입을 변경하고 !isReadOnly이고 핸들링 함수를 props로
전달받았을 경우에만 동작하도록 구현했습니다.
```typescript
 <CodeMirror
        onChange={(newCode) => {
          if (!isReadOnly && handleChangeCode)
            handleChangeCode({ newCode, stringId });
        }}
        ...
      />
```  
```typescript
 <Textarea
          onChange={(e) => {
            if (!isReadOnly && handleChangeMemo) handleChangeMemo(e);
          }}
          ...
        />
```

<br />

### 3️⃣ react-code-mirror에서 readOnly 옵션만으로 읽기 모드 활성화 안되는 이슈
- 읽기 모드는 readOnly 옵션을 true로 만들면 되는데, react-code-mirror는 readOnly 옵션만 활성화시키면 코드의 가장 첫번째 줄은 
읽기 모드가 적용되지 않는 문제가 있었어요 !
   - 라이브러리를 열어서 `editable`이라는 옵션이 있는 걸 확인, 요 옵션을 주었을 때 전체 코드 편집을 막을 수 있더라구용
   - 그래서 최종적으로는 isReadOnly일 경우 readOnly 활성화, editable 비 활성화했습니다 !