### PR TITLE
[ Route ] 선택된 헤더 값에 따라 라우팅 다르게 구현

### DIFF
--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -1,16 +1,33 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '../../common/Header';
 import { PageLayoutProps } from '../../types/PageLayout/PageLayoutType';
 
 const PageLayout = ({ category, children }: PageLayoutProps) => {
+  const navigate = useNavigate();
   const [clickedCategory, setClickedCategory] = useState(category);
+
+  const handleEarlyNavigate = (clickedNav: string) => {
+    switch (clickedNav) {
+      case '홈':
+        return navigate('/');
+      case '문제풀이':
+        return navigate('/solve');
+      case '그룹':
+        return navigate('/group');
+      default:
+        return navigate('/');
+    }
+  };
 
   const handleClickCategory = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
     setClickedCategory(innerHTML);
+
+    handleEarlyNavigate(innerHTML);
   };
 
   return (


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #79 

## ✅ 작업 내용

- [x] 선택된 헤더 값에 따라 라우팅 다르게 구현

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/42c3f62f-0f56-44c5-864c-d03c8845bfe7

## 📌 이슈 사항
### 🚧 라우팅 관련된 사항이라 모든 브랜치/ 컴포넌트에 빠르게 반영하려구 develop에서 분기했습니다 !!

### 1️⃣ 선택된 헤더 값에 따라 라우팅 다르게 구현
- 큰 구현 사항은 없고, 클릭된 값에 따라 라우팅을 다르게 반환했습니다 !
```typescript
  const handleClickCategory = (
    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
  ) => {
    const { innerHTML } = e.currentTarget;
    setClickedCategory(innerHTML);

    handleEarlyNavigate(innerHTML);
  };
```

- 로그인의 경우 헤더 클릭 자체가 안되기 때문에, 클릭 별 라우팅 반환 함수에 넣지 않았습니다 ~
