### PR TITLE
[ Group ] GroupComplete Navigate 연결

### DIFF
--- a/src/assets/icon/thumbnail.svg
+++ b/src/assets/icon/thumbnail.svg
@@ -1,3 +1,0 @@
-<svg width="440" height="310" viewBox="0 0 440 310" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="440" height="310" fill="#D9D9D9"/>
-</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -44,7 +44,6 @@ import IcSuccess from './icon/ic_success.svg?react';
 import IcUnlockGray from './icon/ic_unlock_gray.svg?react';
 import IcUnlockWhite from './icon/ic_unlock_white.svg?react';
 import IcWorkbook from './icon/ic_workbook.svg?react';
-import Thumbnail from './icon/thumbnail.svg?react';
 
 import BtnHeart from './btn/btn_heart.svg?react';
 import BtnJoinGitHub from './btn/btn_join_github.svg?react';
@@ -104,5 +103,4 @@ export {
   IcUnlockWhite,
   IcWorkbook,
   TestWeekboardStatus,
-  Thumbnail,
 };

--- a/src/components/GroupCreate/CreateButton.tsx
+++ b/src/components/GroupCreate/CreateButton.tsx
@@ -2,13 +2,13 @@ import styled from 'styled-components';
 import CommonButton from '../../common/CommonButton';
 import { CreateButtonProps } from '../../types/GroupCreate/GroupCreateType';
 
-const CreateButton = ({ isActive, onClick }: CreateButtonProps) => {
+const CreateButton = ({ isActive, handleGroupCreate }: CreateButtonProps) => {
   return (
     <CreateBtnContainer>
       <CommonButton
         isActive={isActive}
         category="group_create"
-        onClick={onClick}
+        onClick={handleGroupCreate}
       />
     </CreateBtnContainer>
   );

--- a/src/components/GroupCreate/CreateButton.tsx
+++ b/src/components/GroupCreate/CreateButton.tsx
@@ -2,17 +2,13 @@ import styled from 'styled-components';
 import CommonButton from '../../common/CommonButton';
 import { CreateButtonProps } from '../../types/GroupCreate/GroupCreateType';
 
-const CreateButton = ({ isActive }: CreateButtonProps) => {
-  const handleCreateButtonClick = () => {
-    console.log('navigator 로 이동 로직 구현');
-  };
-
+const CreateButton = ({ isActive, onClick }: CreateButtonProps) => {
   return (
     <CreateBtnContainer>
       <CommonButton
         isActive={isActive}
         category="group_create"
-        onClick={handleCreateButtonClick}
+        onClick={onClick}
       />
     </CreateBtnContainer>
   );

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -1,20 +1,24 @@
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonButton from '../common/CommonButton';
+import Modal from '../common/Modal/Modal';
 import PageLayout from '../components/PageLayout/PageLayout';
 import { handleCopyClipBoard } from '../utils/handleCopyClipBoard';
 
-// props 타입 정의해둔 것 지워주세용 !
 const GroupComplete = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const { groupPassword, thumbnailUrl } = state;
   const baseUrl = window.location.origin; // 생성한 그룹 페이지가 만들어지면 대체 될 예정
+  const [isCopied, setIsCopied] = useState(false);
 
   const handleClickCopyBtn = () => {
-    handleCopyClipBoard({ baseUrl: baseUrl, isUsedBaseUrl: true })
-      .then(() => alert('링크가 복사되었습니다.'))
-      .catch(() => navigate('/error'));
+    handleCopyClipBoard({ baseUrl: baseUrl, isUsedBaseUrl: true });
+    setIsCopied(true);
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
   };
 
   const handleGroupPageRedirect = () => {
@@ -38,6 +42,7 @@ const GroupComplete = () => {
           onClick={() => handleClickCopyBtn()}
           category="link_copy"
         />
+        {isCopied && <Modal />}
         <CommonButton
           onClick={handleGroupPageRedirect}
           category="group_direct"

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -35,17 +35,19 @@ const GroupComplete = () => {
             비밀번호 <Password>{groupPassword}</Password>
           </PasswordText>
         ) : (
-          <PasswordText>승인 후 알려드림</PasswordText>
+          <PasswordText>그룹장이 승인 후 알려드릴게요</PasswordText>
         )}
       </PasswordContainer>
       <ThumbnailContainer>
         <Img src={thumbnailUrl} alt="썸네일" />
       </ThumbnailContainer>
       <ButtonContainer>
-        <CommonButton
-          onClick={() => handleClickCopyBtn()}
-          category="link_copy"
-        />
+        {groupPassword && (
+          <CommonButton
+            onClick={() => handleClickCopyBtn()}
+            category="link_copy"
+          />
+        )}
         {isCopied && <Modal />}
         <CommonButton
           onClick={handleGroupPageRedirect}

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -9,7 +9,7 @@ import { handleCopyClipBoard } from '../utils/handleCopyClipBoard';
 const GroupComplete = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
-  const { groupPassword, thumbnailUrl } = state;
+  const { groupPassword, thumbnailUrl } = state || {};
   const baseUrl = window.location.origin; // 생성한 그룹 페이지가 만들어지면 대체 될 예정
   const [isCopied, setIsCopied] = useState(false);
 
@@ -30,9 +30,13 @@ const GroupComplete = () => {
     <PageLayout category={'group_create'}>
       <Title>그룹 생성이 완료되었어요!</Title>
       <PasswordContainer>
-        <PasswordText>
-          비밀번호 <Password>{groupPassword}</Password>
-        </PasswordText>
+        {groupPassword ? (
+          <PasswordText>
+            비밀번호 <Password>{groupPassword}</Password>
+          </PasswordText>
+        ) : (
+          <PasswordText>승인 후 알려드림</PasswordText>
+        )}
       </PasswordContainer>
       <ThumbnailContainer>
         <Img src={thumbnailUrl} alt="썸네일" />
@@ -64,10 +68,13 @@ const Title = styled.h1`
 
 const PasswordContainer = styled.div`
   margin-bottom: 4rem;
+
+  /* background-color: blue; */
 `;
 
 const PasswordText = styled.p`
   ${({ theme }) => theme.fonts.title_bold_20};
+  /* background-color: pink; */
   color: ${({ theme }) => theme.colors.gray100};
 `;
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -68,7 +68,7 @@ const GroupCreate = () => {
     setIsActive(allFieldsFilled || (isPublicGroup && allFieldsFilled));
   }, [inputs, isPublicGroup]);
 
-  const handleSubmit = () => {
+  const handleGroupCreate = () => {
     navigate('/group-complete', {
       state: {
         groupPassword: inputs.secretKey,
@@ -109,7 +109,7 @@ const GroupCreate = () => {
           progressValue={inputs.group}
           handleChangeTextarea={handleChangeInputs}
         />
-        <CreateButton isActive={isActive} onClick={handleSubmit} />
+        <CreateButton isActive={isActive} onClick={handleGroupCreate} />
       </Form>
     </PageLayout>
   );

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -109,7 +109,10 @@ const GroupCreate = () => {
           progressValue={inputs.group}
           handleChangeTextarea={handleChangeInputs}
         />
-        <CreateButton isActive={isActive} onClick={handleGroupCreate} />
+        <CreateButton
+          isActive={isActive}
+          handleGroupCreate={handleGroupCreate}
+        />
       </Form>
     </PageLayout>
   );

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import CreateButton from '../components/GroupCreate/CreateButton';
 import GroupSetting from '../components/GroupCreate/GroupSetting';
@@ -23,6 +24,7 @@ const GroupCreate = () => {
   const [isActive, setIsActive] = useState(false);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const navigate = useNavigate();
 
   const handleChangeInputs = <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.ChangeEvent<T>
@@ -66,6 +68,15 @@ const GroupCreate = () => {
     setIsActive(allFieldsFilled || (isPublicGroup && allFieldsFilled));
   }, [inputs, isPublicGroup]);
 
+  const handleSubmit = () => {
+    navigate('/group-complete', {
+      state: {
+        groupPassword: inputs.secretKey,
+        thumbnailUrl: previewImage as string,
+      },
+    });
+  };
+
   return (
     <PageLayout category="group">
       <Form>
@@ -98,7 +109,7 @@ const GroupCreate = () => {
           progressValue={inputs.group}
           handleChangeTextarea={handleChangeInputs}
         />
-        <CreateButton isActive={isActive} />
+        <CreateButton isActive={isActive} onClick={handleSubmit} />
       </Form>
     </PageLayout>
   );

--- a/src/types/GroupCreate/GroupCreateType.tsx
+++ b/src/types/GroupCreate/GroupCreateType.tsx
@@ -12,7 +12,7 @@ export interface ProgressSectionProps {
 
 export interface CreateButtonProps {
   isActive: boolean;
-  onClick: () => void;
+  handleGroupCreate: () => void;
 }
 
 export interface ImageSectionProps {

--- a/src/types/GroupCreate/GroupCreateType.tsx
+++ b/src/types/GroupCreate/GroupCreateType.tsx
@@ -12,6 +12,7 @@ export interface ProgressSectionProps {
 
 export interface CreateButtonProps {
   isActive: boolean;
+  onClick: () => void;
 }
 
 export interface ImageSectionProps {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #104 

## ✅ 작업 내용

- [x] 공통 모달 사용
- [x] 비밀번호 값이 들어오냐에 따라 다르게 렌더링

## 📸 스크린샷 / GIF / Link
### 공개 그룹 버튼

https://github.com/user-attachments/assets/a606c5a3-f35e-491d-ad4c-04b0b2a81d8e

### 비밀 그룹 버튼

https://github.com/user-attachments/assets/28b8cfd1-5844-4db8-81de-bc5ad644ba80

## 📌 이슈 사항

### 1️⃣ CompletePage navigate 를 활용하여 state 전달

GroupComplete 페이지에서 state 값으로 useLocation 을 받고있다.

useLocation 훅을 사용하면 현재 위치에 대한 정보를 가져올 수 있다. 이 훅을 사용하여 navigate를 통해 다른 페이지로 이동할 때 전달한 상태를 가져올 수 있는데 우리는 `groupPassword` 와 `thumbnailUrl` 이 두개가 state로 필요했던 것.

현재 이 페이지는 그룹생성 후→ 그룹 참여가 완료되었다는 페이지이다.

```jsx
const GroupComplete = () => {
  const navigate = useNavigate();
  const { state } = useLocation();
  const { groupPassword, thumbnailUrl } = state;
  
  return (
    <PageLayout category={'group_create'}>
      <Title>그룹 생성이 완료되었어요!</Title>
      <PasswordContainer>
        <PasswordText>
          비밀번호 <Password>{groupPassword}</Password>
        </PasswordText>
      </PasswordContainer>
      <ThumbnailContainer>
        <Img src={thumbnailUrl} alt="썸네일" />
      </ThumbnailContainer>
      <ButtonContainer>
        <CommonButton
          onClick={() => handleClickCopyBtn()}
          category="link_copy"
        />
        <CommonButton
          onClick={handleGroupPageRedirect}
          category="group_direct"
          isActive={true}
        />
      </ButtonContainer>
    </PageLayout>
  );
};
```

### 상태 전달의 과정

1.handleSubmit 함수는 navigate 함수를 이용하여 group-complete 페이지로 이동. 이 때 state 객체에서 `groupPassword`와`thumbnailUrl
값을 설정하여 함께 전달.`

```jsx
const handleSubmit = () => {
  navigate('/group-complete', {
    state: {
      groupPassword: inputs.secretKey,
      thumbnailUrl: previewImage,
    },
  });
};
```

2.useLocation 훅을 사용하여 현재 위치의 상태 객체 가져옴. 

```jsx
const { state } = useLocation();
const { groupPassword, thumbnailUrl } = state;
```

`GroupComplete` 페이지에서는 `useLocation` 사용하여 현재 위치의 객체를 가져옴. 그리고 이 객체에서 `groupPassword`와 `thumbnailUrl` 값을 가져와 사용


### 2️⃣ 공통 Modal 사용 ( Group-Complete 링크복사)

아름이가 사용한 코드를 참고하여 만들었습니다 ! 
`const [isCopied, setIsCopied] = useState (false)`를 활용하여 만들었습니다.

```jsx
const handleClickCopyBtn = () => {
    handleCopyClipBoard({ baseUrl: baseUrl, isUsedBaseUrl: true });
    setIsCopied(true);
    setTimeout(() => {
      setIsCopied(false);
    }, 1000);
  };
  
  return (
    <PageLayout category={'group_create'}>
      <Title>그룹 생성이 완료되었어요!</Title>
      <PasswordContainer>
        <PasswordText>
          비밀번호 <Password>{groupPassword}</Password>
        </PasswordText>
      </PasswordContainer>
      <ThumbnailContainer>
        <Img src={thumbnailUrl} alt="썸네일" />
      </ThumbnailContainer>
      <ButtonContainer>
        <CommonButton
          onClick={() => handleClickCopyBtn()}
          category="link_copy"
        />
        {isCopied && <Modal />}
        <CommonButton
          onClick={handleGroupPageRedirect}
          category="group_direct"
          isActive={true}
        />
      </ButtonContainer>
    </PageLayout>
  );
```
아름이가 만든 공통모달 사용법입니다 ! 
https://github.com/Co-Drive/Driver-Client/pull/78

### 3️⃣ CreatePage 에서 비밀번호 입력에 따라 GroupComplete 페이지 다르게 렌더링

사실 `state || {}`  이렇게 안넣어줘도 실행은 됩니다.

하지만 `useLocation`  반환된 `state` 객체가 undefined인 경우를 고려하여 코드를 조금 더 안전하게 작성하고 싶어 추가해주었습니다. (에러방지)

```jsx
const { groupPassword, thumbnailUrl } = state || {};

<PasswordContainer>
    {groupPassword ? (
      <PasswordText>
         비밀번호 <Password>{groupPassword}</Password>
      </PasswordText>
     ) : (
      <PasswordText>승인 후 알려드림</PasswordText>
     )}
```

## ✍ 궁금한 것
