### PR TITLE
[ Solution ] 풀었던 문제 리스트 컴포넌트 퍼블리싱

### DIFF
--- a/src/assets/icon/ic_arrow__top_white.svg
+++ b/src/assets/icon/ic_arrow__top_white.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 15L12 9L18 15" stroke="white" stroke-width="2"/>
+</svg>

--- a/src/assets/icon/ic_arrow_bottom_white.svg
+++ b/src/assets/icon/ic_arrow_bottom_white.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 9L12 15L18 9" stroke="white" stroke-width="2"/>
+</svg>

--- a/src/assets/icon/ic_calendar.svg
+++ b/src/assets/icon/ic_calendar.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.76074 9.59898H20.248" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M16.1087 13.2118H16.1173" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M12.0043 13.2118H12.0128" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M7.89097 13.2118H7.89954" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M16.1087 16.8065H16.1173" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M12.0043 16.8065H12.0128" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M7.89097 16.8065H7.89954" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M15.741 2.75V5.79399" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path d="M8.26831 2.75V5.79399" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20.3258 4.21094H3.67578V21.2503H20.3258V4.21094Z" stroke="white" stroke-width="1.5" stroke-linecap="square"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -6,6 +6,7 @@ import IcAddFill from './icon/ic_add_fill.svg?react';
 import IcAddFillDisabled from './icon/ic_add_fill_disabled.svg?react';
 import IcAddGray from './icon/ic_add_gray.svg?react';
 import IcAddPhoto from './icon/ic_add_photo.svg?react';
+import IcArrowTopWhite from './icon/ic_arrow__top_white.svg?react';
 import IcArrowBottomGray from './icon/ic_arrow_bottom_gray.svg?react';
 import IcArrowBottomWhite from './icon/ic_arrow_bottom_white.svg?react';
 import IcArrowLeftFill from './icon/ic_arrow_left_fill.svg?react';
@@ -82,6 +83,7 @@ export {
   IcArrowRightGray,
   IcArrowRightSmallGray,
   IcArrowTopGray,
+  IcArrowTopWhite,
   IcArrowUpBig,
   IcBtnCopy,
   IcBtnInformation,

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -7,6 +7,7 @@ import IcAddFillDisabled from './icon/ic_add_fill_disabled.svg?react';
 import IcAddGray from './icon/ic_add_gray.svg?react';
 import IcAddPhoto from './icon/ic_add_photo.svg?react';
 import IcArrowBottomGray from './icon/ic_arrow_bottom_gray.svg?react';
+import IcArrowBottomWhite from './icon/ic_arrow_bottom_white.svg?react';
 import IcArrowLeftFill from './icon/ic_arrow_left_fill.svg?react';
 import IcArrowLeftSmallGray from './icon/ic_arrow_left_small_gray.svg?react';
 import IcArrowRightBig from './icon/ic_arrow_right_big.svg?react';
@@ -18,6 +19,7 @@ import IcArrowTopGray from './icon/ic_arrow_top_gray.svg?react';
 import IcArrowUpBig from './icon/ic_arrow_up_big.svg?react';
 import IcBtnCopy from './icon/ic_btn_copy.svg?react';
 import IcBtnInformation from './icon/ic_btn_information.svg?react';
+import IcCalendar from './icon/ic_calendar.svg?react';
 import IcCancelFill from './icon/ic_cancel_fill.svg?react';
 import IcCancelSmall from './icon/ic_cancel_small.svg?react';
 import IcCancelSmallWhite from './icon/ic_cancel_small_white.svg?react';
@@ -71,6 +73,7 @@ export {
   IcAddGray,
   IcAddPhoto,
   IcArrowBottomGray,
+  IcArrowBottomWhite,
   IcArrowLeftFill,
   IcArrowLeftSmallGray,
   IcArrowRightBig,
@@ -82,6 +85,7 @@ export {
   IcArrowUpBig,
   IcBtnCopy,
   IcBtnInformation,
+  IcCalendar,
   IcCancelFill,
   IcCancelSmall,
   IcCancelSmallWhite,

--- a/src/components/Solution/Level.tsx
+++ b/src/components/Solution/Level.tsx
@@ -1,9 +1,6 @@
 import styled from 'styled-components';
 import { BtnStarGraySmall, BtnStarPurpleSmall } from '../../assets';
-
-interface LevelProps {
-  level: number;
-}
+import { LevelProps } from '../../types/Solution/solutionTypes';
 
 const Level = ({ level }: LevelProps) => {
   const paintedStarArr = Array(level)

--- a/src/components/Solution/Level.tsx
+++ b/src/components/Solution/Level.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { BtnStarGraySmall, BtnStarPurpleSmall } from '../../assets';
+
+interface LevelProps {
+  level: number;
+}
+
+const Level = ({ level }: LevelProps) => {
+  const paintedStarArr = Array(level)
+    .fill(1)
+    .concat(Array(5 - level).fill(0));
+
+  return (
+    <LevelContainer>
+      <LvText>난이도</LvText>
+      <LvText>|</LvText>
+      <LvStarContainer>
+        {paintedStarArr.map((painted, idx) => {
+          return (
+            <li key={idx}>
+              {painted ? <BtnStarPurpleSmall /> : <BtnStarGraySmall />}
+            </li>
+          );
+        })}
+      </LvStarContainer>
+    </LevelContainer>
+  );
+};
+
+export default Level;
+
+const LevelContainer = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+`;
+
+const LvText = styled.p`
+  ${({ theme }) => theme.fonts.title_bold_16};
+  color: ${({ theme }) => theme.colors.gray300};
+`;
+
+const LvStarContainer = styled.ul`
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Solution/List/Calendar.tsx
+++ b/src/components/Solution/List/Calendar.tsx
@@ -17,7 +17,9 @@ const Calendar = ({
   handleClickMonth,
   handleClickNextBtn,
 }: CalendarProps) => {
+  // 선택된 년도 별로 서버에서 받아올 예정 !
   const dummy = [1, 3, 5, 10];
+
   const year = new Date().getFullYear();
   const { clickedYear, clickedMonth } = date;
   const monthCalendar = Array.from({ length: 12 }, (_, idx) => idx + 1);

--- a/src/components/Solution/List/Calendar.tsx
+++ b/src/components/Solution/List/Calendar.tsx
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../../assets';
+
+interface CalendarProps {
+  date: {
+    year: number;
+    month: number;
+  };
+  handleClickPrevBtn: () => void;
+  handleClickMonth: (month: number) => void;
+  handleClickNextBtn: () => void;
+}
+
+const Calendar = ({
+  date,
+  handleClickPrevBtn,
+  handleClickMonth,
+  handleClickNextBtn,
+}: CalendarProps) => {
+  const { year, month } = date;
+  const monthCalendar = Array.from({ length: 12 }, (_, idx) => idx + 1);
+  return (
+    <CalendarContainer>
+      <YearContainer>
+        <IcArrowLeftSmallGray onClick={handleClickPrevBtn} />
+        <Year>{year}</Year>
+        <IcArrowRightSmallGray onClick={handleClickNextBtn} />
+      </YearContainer>
+
+      <MonthBoard>
+        {monthCalendar.map((month) => {
+          return <Month key={month}>{month}</Month>;
+        })}
+      </MonthBoard>
+    </CalendarContainer>
+  );
+};
+
+export default Calendar;
+
+const CalendarContainer = styled.article`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 5.6rem;
+
+  width: 100%;
+`;
+
+const YearContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  padding: 1rem 1.2rem;
+
+  border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray500};
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.colors.gray600};
+`;
+
+const Year = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_semiBold_14};
+`;
+
+const MonthBoard = styled.div`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, 1fr);
+
+  width: 100%;
+  padding: 1.7rem 1.9rem 1.7rem 1.8rem;
+
+  background-color: ${({ theme }) => theme.colors.gray700};
+  border-bottom-left-radius: 1.2rem;
+  border-bottom-right-radius: 1.2rem;
+`;
+
+const Month = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 2.8rem;
+  height: 2.8rem;
+
+  border-radius: 3rem;
+  color: ${({ theme }) => theme.colors.gray400};
+  ${({ theme }) => theme.fonts.title_bold_14};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray500};
+    color: ${({ theme }) => theme.colors.gray100};
+  }
+`;

--- a/src/components/Solution/List/Calendar.tsx
+++ b/src/components/Solution/List/Calendar.tsx
@@ -1,10 +1,10 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../../assets';
 
 interface CalendarProps {
   date: {
-    year: number;
-    month: number;
+    clickedYear: number;
+    clickedMonth: number;
   };
   handleClickPrevBtn: () => void;
   handleClickMonth: (month: number) => void;
@@ -17,19 +17,31 @@ const Calendar = ({
   handleClickMonth,
   handleClickNextBtn,
 }: CalendarProps) => {
-  const { year, month } = date;
+  const dummy = [1, 3, 5, 10];
+  const year = new Date().getFullYear();
+  const { clickedYear, clickedMonth } = date;
   const monthCalendar = Array.from({ length: 12 }, (_, idx) => idx + 1);
   return (
     <CalendarContainer>
       <YearContainer>
         <IcArrowLeftSmallGray onClick={handleClickPrevBtn} />
-        <Year>{year}</Year>
+        <Year>{clickedYear}</Year>
         <IcArrowRightSmallGray onClick={handleClickNextBtn} />
       </YearContainer>
 
       <MonthBoard>
         {monthCalendar.map((month) => {
-          return <Month key={month}>{month}</Month>;
+          const disabled = dummy.includes(month) || clickedYear > year;
+          return (
+            <Month
+              key={month}
+              $disabled={disabled}
+              $isClicked={clickedMonth === month}
+              onClick={() => !disabled && handleClickMonth(month)}
+            >
+              {month}
+            </Month>
+          );
         })}
       </MonthBoard>
     </CalendarContainer>
@@ -78,7 +90,7 @@ const MonthBoard = styled.div`
   border-bottom-right-radius: 1.2rem;
 `;
 
-const Month = styled.span`
+const Month = styled.span<{ $isClicked: boolean; $disabled: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -87,11 +99,25 @@ const Month = styled.span`
   height: 2.8rem;
 
   border-radius: 3rem;
-  color: ${({ theme }) => theme.colors.gray400};
-  ${({ theme }) => theme.fonts.title_bold_14};
 
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.gray500};
-    color: ${({ theme }) => theme.colors.gray100};
-  }
+  ${({ $disabled, $isClicked }) =>
+    $disabled
+      ? css`
+          color: ${({ theme }) => theme.colors.gray400};
+        `
+      : $isClicked
+        ? css`
+            background-color: ${({ theme }) => theme.colors.codrive_green};
+            color: ${({ theme }) => theme.colors.gray900};
+          `
+        : css`
+            color: ${({ theme }) => theme.colors.white};
+
+            &:hover {
+              background-color: ${({ theme }) => theme.colors.gray500};
+              color: ${({ theme }) => theme.colors.gray100};
+            }
+          `};
+
+  ${({ theme }) => theme.fonts.title_bold_14};
 `;

--- a/src/components/Solution/List/Calendar.tsx
+++ b/src/components/Solution/List/Calendar.tsx
@@ -1,15 +1,6 @@
 import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../../assets';
-
-interface CalendarProps {
-  date: {
-    clickedYear: number;
-    clickedMonth: number;
-  };
-  handleClickPrevBtn: () => void;
-  handleClickMonth: (month: number) => void;
-  handleClickNextBtn: () => void;
-}
+import { CalendarProps } from '../../../types/Solution/solutionTypes';
 
 const Calendar = ({
   date,

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { IcArrowBottomWhite, IcCalendar } from '../../../assets';
+
+const ListFilter = () => {
+  const LIST_SORTING = ['최신순', '|', '즐겨찾기'];
+  const YEAR = new Date().getFullYear();
+  const MONTH = new Date().getMonth();
+
+  const [selectedDate, setSelectedDate] = useState({
+    year: YEAR,
+    month: MONTH,
+  });
+  const [sorting, setSorting] = useState('최신순');
+
+  const { year, month } = selectedDate;
+
+  const handleClickSorting = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
+  ) => {
+    const { innerHTML } = e.currentTarget;
+    setSorting(innerHTML);
+    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
+  };
+
+  return (
+    <FilteredContainer>
+      <MonthFilterContainer>
+        <IcCalendar />
+        <DateContainer>
+          <Year>{year}년</Year>
+          <Month>{month}월</Month>
+        </DateContainer>
+        <IcArrowBottomWhite />
+      </MonthFilterContainer>
+      <SortContainer>
+        {LIST_SORTING.map((standard) => {
+          return (
+            <Sorting
+              key={standard}
+              onClick={(
+                e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
+              ) => standard !== '|' && handleClickSorting(e)}
+              $isClicked={sorting === standard}
+            >
+              {standard}
+            </Sorting>
+          );
+        })}
+      </SortContainer>
+    </FilteredContainer>
+  );
+};
+
+export default ListFilter;
+
+const FilteredContainer = styled.header`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+`;
+
+const MonthFilterContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  padding: 1.3rem 1.4rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.gray700};
+`;
+
+const DateContainer = styled.div`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+
+  margin-right: 1rem;
+  margin-left: 1.4rem;
+`;
+
+const Year = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.body_medium_16};
+`;
+
+const Month = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.body_medium_16};
+`;
+
+const SortContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+`;
+
+const Sorting = styled.p<{ $isClicked: boolean }>`
+  color: ${({ $isClicked, theme }) =>
+    $isClicked ? theme.colors.white : theme.colors.gray500};
+  ${({ theme }) => theme.fonts.body_medium_14};
+`;

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -1,12 +1,18 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { IcArrowBottomWhite, IcCalendar } from '../../../assets';
+import {
+  IcArrowBottomWhite,
+  IcArrowTopWhite,
+  IcCalendar,
+} from '../../../assets';
+import Calendar from './Calendar';
 
 const ListFilter = () => {
   const LIST_SORTING = ['최신순', '|', '즐겨찾기'];
   const YEAR = new Date().getFullYear();
   const MONTH = new Date().getMonth();
 
+  const [isCalendarClicked, setIsCalendarClicked] = useState(false);
   const [selectedDate, setSelectedDate] = useState({
     year: YEAR,
     month: MONTH,
@@ -14,6 +20,31 @@ const ListFilter = () => {
   const [sorting, setSorting] = useState('최신순');
 
   const { year, month } = selectedDate;
+
+  const handleClickDateFilter = () => {
+    setIsCalendarClicked(!isCalendarClicked);
+  };
+
+  const handleClickPrevBtn = () => {
+    setSelectedDate({
+      ...selectedDate,
+      year: year - 1,
+    });
+  };
+
+  const handleClickMonth = (month: number) => {
+    setSelectedDate({
+      ...selectedDate,
+      month: month,
+    });
+  };
+
+  const handleClickNextBtn = () => {
+    setSelectedDate({
+      ...selectedDate,
+      year: year + 1,
+    });
+  };
 
   const handleClickSorting = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
@@ -25,14 +56,28 @@ const ListFilter = () => {
 
   return (
     <FilteredContainer>
-      <MonthFilterContainer>
-        <IcCalendar />
-        <DateContainer>
+      <DateFilterContainer>
+        <IcCalendar onClick={handleClickDateFilter} />
+        <DateContainer onClick={handleClickDateFilter}>
           <Year>{year}년</Year>
           <Month>{month}월</Month>
         </DateContainer>
-        <IcArrowBottomWhite />
-      </MonthFilterContainer>
+
+        {isCalendarClicked ? (
+          <>
+            <IcArrowTopWhite onClick={handleClickDateFilter} />
+            <Calendar
+              date={{ year, month }}
+              handleClickPrevBtn={handleClickPrevBtn}
+              handleClickMonth={handleClickMonth}
+              handleClickNextBtn={handleClickNextBtn}
+            />
+          </>
+        ) : (
+          <IcArrowBottomWhite onClick={handleClickDateFilter} />
+        )}
+      </DateFilterContainer>
+
       <SortContainer>
         {LIST_SORTING.map((standard) => {
           return (
@@ -61,15 +106,20 @@ const FilteredContainer = styled.header`
   width: 100%;
 `;
 
-const MonthFilterContainer = styled.div`
+const DateFilterContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 
   padding: 1.3rem 1.4rem;
 
+  outline: 0.1rem solid ${({ theme }) => theme.colors.gray500};
+
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray700};
+
+  min-width: 17.9rem;
 `;
 
 const DateContainer = styled.div`

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -67,7 +67,7 @@ const ListFilter = () => {
           <>
             <IcArrowTopWhite onClick={handleClickDateFilter} />
             <Calendar
-              date={{ year, month }}
+              date={{ clickedYear: year, clickedMonth: month }}
               handleClickPrevBtn={handleClickPrevBtn}
               handleClickMonth={handleClickMonth}
               handleClickNextBtn={handleClickNextBtn}
@@ -114,12 +114,12 @@ const DateFilterContainer = styled.div`
 
   padding: 1.3rem 1.4rem;
 
-  outline: 0.1rem solid ${({ theme }) => theme.colors.gray500};
-
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray700};
 
-  min-width: 17.9rem;
+  outline: 0.1rem solid ${({ theme }) => theme.colors.gray500};
+
+  min-width: 18.52rem;
 `;
 
 const DateContainer = styled.div`
@@ -127,8 +127,9 @@ const DateContainer = styled.div`
   gap: 0.4rem;
   align-items: center;
 
-  margin-right: 1rem;
-  margin-left: 1.4rem;
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1.4rem;
 `;
 
 const Year = styled.p`

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -112,14 +112,15 @@ const DateFilterContainer = styled.div`
   align-items: center;
   position: relative;
 
+  max-width: 17.9rem;
+
+  width: 17.9rem;
   padding: 1.3rem 1.4rem;
 
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray700};
 
   outline: 0.1rem solid ${({ theme }) => theme.colors.gray500};
-
-  min-width: 18.52rem;
 `;
 
 const DateContainer = styled.div`
@@ -128,7 +129,7 @@ const DateContainer = styled.div`
   align-items: center;
 
   width: 100%;
-  padding-right: 1rem;
+  padding-right: 0.4rem;
   padding-left: 1.4rem;
 `;
 

--- a/src/components/Solution/List/SavedSolution.tsx
+++ b/src/components/Solution/List/SavedSolution.tsx
@@ -1,12 +1,18 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowRightGray, IcLinkWhite } from '../../../assets';
 import { SavedSolutionProps } from '../../../types/Solution/solutionTypes';
 import Level from '../Level';
 
 const SavedSolution = ({ record }: SavedSolutionProps) => {
+  const navigate = useNavigate();
   const { recordId, title, level, tags, platform, problemUrl, createdAt } =
     record;
   const [month, date] = createdAt.split('.');
+
+  const handleClickArrow = () => {
+    navigate(`/solution/${recordId}`);
+  };
 
   return (
     <SavedSolutionContainer>
@@ -29,7 +35,7 @@ const SavedSolution = ({ record }: SavedSolutionProps) => {
         </Question>
       </QuesitonContainer>
 
-      <IcArrowRightGray />
+      <IcArrowRightGray onClick={handleClickArrow} />
     </SavedSolutionContainer>
   );
 };

--- a/src/components/Solution/List/SavedSolution.tsx
+++ b/src/components/Solution/List/SavedSolution.tsx
@@ -1,0 +1,108 @@
+import styled from 'styled-components';
+import { IcArrowRightGray, IcLinkWhite } from '../../../assets';
+import { SavedSolutionProps } from '../../../types/Solution/solutionTypes';
+import Level from '../Level';
+
+const SavedSolution = ({ record }: SavedSolutionProps) => {
+  const { recordId, title, level, tags, platform, problemUrl, createdAt } =
+    record;
+  const [month, date] = createdAt.split('.');
+
+  return (
+    <SavedSolutionContainer>
+      <QuesitonContainer>
+        <Date>
+          {month}월 {date}일
+        </Date>
+
+        <Question>
+          <Title>{title}</Title>
+          <TagContainer>
+            <Tag>{tags.join(', ')}</Tag>
+            <Tag>{platform}</Tag>
+            <LinkBtn type="button">
+              <IcLinkWhite />
+              <Link onClick={() => window.open(problemUrl)}>링크 바로가기</Link>
+            </LinkBtn>
+          </TagContainer>
+          <Level level={level} />
+        </Question>
+      </QuesitonContainer>
+
+      <IcArrowRightGray />
+    </SavedSolutionContainer>
+  );
+};
+
+export default SavedSolution;
+
+const SavedSolutionContainer = styled.article`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+  padding: 2.4rem 2.3rem 3rem 0.6rem;
+`;
+
+const QuesitonContainer = styled.article`
+  display: flex;
+  gap: 9.7rem;
+`;
+
+const Date = styled.p`
+  color: ${({ theme }) => theme.colors.gray100};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Question = styled.article`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const Title = styled.p`
+  margin-bottom: 1.8rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+
+  margin-bottom: 1.4rem;
+`;
+
+const Tag = styled.span`
+  max-width: 29.2rem;
+
+  overflow-x: hidden;
+
+  padding: 1.1rem 1.6rem;
+
+  border-radius: 0.6rem;
+  background-color: ${({ theme }) => theme.colors.gray600};
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_semiBold_14};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const LinkBtn = styled.button`
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+
+  padding: 0.8rem 1.6rem 0.7rem 1.2rem;
+
+  border-radius: 0.6rem;
+  background-color: ${({ theme }) => theme.colors.gray600};
+`;
+
+const Link = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_semiBold_14};
+`;

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import ListFilter from './ListFilter';
+import SavedSolution from './SavedSolution';
+
+const SavedSolutionList = () => {
+  return (
+    <ListContainer>
+      <ListFilter />
+      <SavedSolution />
+    </ListContainer>
+  );
+};
+
+export default SavedSolutionList;
+
+const ListContainer = styled.article`
+  display: flex;
+  gap: 2.2rem;
+  align-items: center;
+  flex-direction: column;
+  
+  margin-top: 4.3rem;
+`;

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -8,7 +8,7 @@ const SAVED_DUMMY = {
   totalPage: 2,
   records: [
     {
-      recordId: 0,
+      recordId: 1,
       title: '문제 풀이 제목',
       level: 1,
       tags: ['완전탐색'],
@@ -17,7 +17,7 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 1,
+      recordId: 2,
       title: '문제 풀이 제목',
       level: 1,
       tags: ['동적계획법 (Dynamic Programming)', '깊이 우선탐색 (DFS)'],
@@ -26,7 +26,7 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 2,
+      recordId: 3,
       title: '문제 풀이 제목',
       level: 1,
       tags: ['동적계획법 (Dynamic Programming)'],
@@ -35,7 +35,7 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 3,
+      recordId: 4,
       title: '문제 풀이 제목',
       level: 2,
       tags: ['정렬', '힙 (Heap)'],
@@ -44,7 +44,7 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 4,
+      recordId: 5,
       title: '문제 풀이 제목',
       level: 5,
       tags: ['깊이 우선탐색 (DFS)'],
@@ -53,7 +53,7 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 5,
+      recordId: 6,
       title: '문제 풀이 제목',
       level: 3,
       tags: ['구현', '탐욕법 (Greedy)'],
@@ -62,28 +62,10 @@ const SAVED_DUMMY = {
       createdAt: '02.05',
     },
     {
-      recordId: 6,
+      recordId: 7,
       title: '문제 풀이 제목',
       level: 2,
       tags: ['스택/큐', '해시'],
-      platform: 'BAEKJOON',
-      problemUrl: 'PROBLEM_URL',
-      createdAt: '02.05',
-    },
-    {
-      recordId: 7,
-      title: '문제 풀이 제목',
-      level: 1,
-      tags: ['완전탐색', '너비 우선 탐색 (BFS)'],
-      platform: 'BAEKJOON',
-      problemUrl: 'PROBLEM_URL',
-      createdAt: '02.05',
-    },
-    {
-      recordId: 8,
-      title: '문제 풀이 제목',
-      level: 3,
-      tags: ['완전탐색', '해시'],
       platform: 'BAEKJOON',
       problemUrl: 'PROBLEM_URL',
       createdAt: '02.05',

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -1,4 +1,6 @@
-import styled from 'styled-components';
+import { useState } from 'react';
+import styled, { css } from 'styled-components';
+import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../../assets';
 import ListFilter from './ListFilter';
 import SavedSolution from './SavedSolution';
 
@@ -90,7 +92,24 @@ const SAVED_DUMMY = {
 };
 
 const SavedSolutionList = () => {
+  const [clickedPage, setClickedPage] = useState(1);
+
   const { totalPage, records } = SAVED_DUMMY;
+  const pages = Array.from({ length: totalPage }, (_, idx) => idx + 1);
+
+  // 페이지 별 문제 리스트 요청 함수 추가할 예정 ! -> 페이지 이동 함수들에 들어갈 것임
+
+  const handleClickPrevBtn = () => {
+    setClickedPage((prev) => prev - 1);
+  };
+
+  const handleClickPageNumber = (page: number) => {
+    setClickedPage(page);
+  };
+
+  const handleClickNextBtn = () => {
+    setClickedPage((prev) => prev + 1);
+  };
 
   return (
     <ListContainer>
@@ -98,6 +117,26 @@ const SavedSolutionList = () => {
       {records.map((record) => {
         return <SavedSolution key={record.recordId} record={record} />;
       })}
+
+      <PageNationBar>
+        <IcArrowLeftSmallGray
+          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
+        />
+        {pages.map((page) => {
+          return (
+            <PageNumber
+              key={page}
+              $isClicked={clickedPage === page}
+              onClick={() => handleClickPageNumber(page)}
+            >
+              {page}
+            </PageNumber>
+          );
+        })}
+        <IcArrowRightSmallGray
+          onClick={() => clickedPage !== totalPage && handleClickNextBtn()}
+        />
+      </PageNationBar>
     </ListContainer>
   );
 };
@@ -109,6 +148,33 @@ const ListContainer = styled.section`
   gap: 2.2rem;
   align-items: center;
   flex-direction: column;
-  
+
   margin-top: 4.3rem;
+`;
+
+const PageNationBar = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  margin-top: 4.8rem;
+`;
+
+const PageNumber = styled.p<{ $isClicked: boolean }>`
+  padding: 0.4rem 1rem;
+
+  border-radius: 0.4rem;
+  ${({ theme, $isClicked }) =>
+    $isClicked
+      ? css`
+          background-color: ${theme.colors.gray700};
+          color: ${theme.colors.white};
+        `
+      : css`
+          background-color: transparent;
+          color: ${theme.colors.gray200};
+        `};
+  ${({ theme }) => theme.fonts.body_medium_16};
 `;

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -104,7 +104,7 @@ const SavedSolutionList = () => {
 
 export default SavedSolutionList;
 
-const ListContainer = styled.article`
+const ListContainer = styled.section`
   display: flex;
   gap: 2.2rem;
   align-items: center;

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -2,11 +2,102 @@ import styled from 'styled-components';
 import ListFilter from './ListFilter';
 import SavedSolution from './SavedSolution';
 
+const SAVED_DUMMY = {
+  totalPage: 2,
+  records: [
+    {
+      recordId: 0,
+      title: '문제 풀이 제목',
+      level: 1,
+      tags: ['완전탐색'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 1,
+      title: '문제 풀이 제목',
+      level: 1,
+      tags: ['동적계획법 (Dynamic Programming)', '깊이 우선탐색 (DFS)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 2,
+      title: '문제 풀이 제목',
+      level: 1,
+      tags: ['동적계획법 (Dynamic Programming)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 3,
+      title: '문제 풀이 제목',
+      level: 2,
+      tags: ['정렬', '힙 (Heap)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 4,
+      title: '문제 풀이 제목',
+      level: 5,
+      tags: ['깊이 우선탐색 (DFS)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 5,
+      title: '문제 풀이 제목',
+      level: 3,
+      tags: ['구현', '탐욕법 (Greedy)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 6,
+      title: '문제 풀이 제목',
+      level: 2,
+      tags: ['스택/큐', '해시'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 7,
+      title: '문제 풀이 제목',
+      level: 1,
+      tags: ['완전탐색', '너비 우선 탐색 (BFS)'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+    {
+      recordId: 8,
+      title: '문제 풀이 제목',
+      level: 3,
+      tags: ['완전탐색', '해시'],
+      platform: 'BAEKJOON',
+      problemUrl: 'PROBLEM_URL',
+      createdAt: '02.05',
+    },
+  ],
+};
+
 const SavedSolutionList = () => {
+  const { totalPage, records } = SAVED_DUMMY;
+
   return (
     <ListContainer>
       <ListFilter />
-      <SavedSolution />
+      {records.map((record) => {
+        return <SavedSolution key={record.recordId} record={record} />;
+      })}
     </ListContainer>
   );
 };

--- a/src/components/Solution/List/TempSave.tsx
+++ b/src/components/Solution/List/TempSave.tsx
@@ -1,24 +1,12 @@
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
-import {
-  BtnStarGraySmall,
-  BtnStarPurpleSmall,
-  IcArrowRightBig,
-} from '../../../assets';
-import {
-  LevelDetailContainer,
-  LvStarContainer,
-  LvText,
-} from '../Header/SolutionHeaderTop';
+import { IcArrowRightBig } from '../../../assets';
+import Level from '../Level';
 
 const TempSave = () => {
   // 임시저장된 리스트 개수 받아오기 -> 그 수로 map 돌려서 숫자 아이콘 만들기
   const DUMMY = 3;
   const DUMMY_ARR = Array.from({ length: DUMMY }, (_, idx) => idx + 1);
-
-  const paintedStarArr = Array(3)
-    .fill(1)
-    .concat(Array(5 - 3).fill(0));
 
   const [isClickedNum, setIsClickedNum] = useState(1);
 
@@ -55,19 +43,8 @@ const TempSave = () => {
             <Time>22시 14분</Time>
           </DateContainer>
         </TopInfo>
-        <LevelDetailContainer>
-          <LvText>난이도</LvText>
-          <LvText>|</LvText>
-          <LvStarContainer>
-            {paintedStarArr.map((painted, idx) => {
-              return (
-                <li key={idx}>
-                  {painted ? <BtnStarPurpleSmall /> : <BtnStarGraySmall />}
-                </li>
-              );
-            })}
-          </LvStarContainer>
-        </LevelDetailContainer>
+        {/* 추후 서버에서 받아온 값으로 변경 예정 */}
+        <Level level={3} />
       </QuestionContainer>
       <WriteBtn type="button">
         <BtnTxt>마저 작성하러 가기</BtnTxt>

--- a/src/page/SolutionListPage.tsx
+++ b/src/page/SolutionListPage.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import PageLayout from '../components/PageLayout/PageLayout';
 import TempSave from '../components/Solution/List/TempSave';
+import SavedSolutionList from '../components/Solution/List/SavedSolutionList';
 
 const SolutionListPage = () => {
   const nickname = sessionStorage.getItem('nickname');
@@ -13,6 +14,8 @@ const SolutionListPage = () => {
         </TitleContainer>
 
         <TempSave />
+
+        <SavedSolutionList />
       </ListPageContainer>
     </PageLayout>
   );

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -33,3 +33,17 @@ export interface SavedSolutionProps {
     createdAt: string;
   };
 }
+
+export interface LevelProps {
+  level: number;
+}
+
+export interface CalendarProps {
+  date: {
+    clickedYear: number;
+    clickedMonth: number;
+  };
+  handleClickPrevBtn: () => void;
+  handleClickMonth: (month: number) => void;
+  handleClickNextBtn: () => void;
+}

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -21,3 +21,15 @@ export interface SolutionHeaderTopProps {
   date: string;
   paintedStarArr: Array<number>;
 }
+
+export interface SavedSolutionProps {
+  record: {
+    recordId: number;
+    title: string;
+    level: number;
+    tags: Array<string>;
+    platform: string;
+    problemUrl: string;
+    createdAt: string;
+  };
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #94 

## ✅ 작업 내용

- [x] 문제 난이도를 별 아이콘으로 보여주는 부분 Solution 내부 공통 컴포넌트로 분리
- [x] 년도 별 캘린더 구현
- [x] 문제 풀이 리스트 컴포넌트 구현
- [x] 페이지네이션 구현

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/5095c7c9-9fde-4f0d-9bd4-819c93fa2d9b


## 📌 이슈 사항
### 1️⃣ 년도 별 캘린더 구현
- 12개의 숫자가 들어가 있는 년도 별 캘린더를 구현했습니다.
- 문제 풀이가 진행되지 않은 달의 정보를 받아와서 문제 풀이 진행 여부에 따라 조건부 스타일링 적용했습니다!
   - 현재는 문제 풀이가 진행되지 않은 달의 정보를 더미데이터로 넣어놨고, 스웨거에 해당 api 가 없어서 서버 측에 요청해둔 상태입니당
   ```typescript
    const dummy = [1, 3, 5, 10];
    
    <MonthBoard>
        {monthCalendar.map((month) => {
          const disabled = dummy.includes(month) || clickedYear > year;
          return (
            <Month
              key={month}
              $disabled={disabled}
              $isClicked={clickedMonth === month}
              onClick={() => !disabled && handleClickMonth(month)}
            >
              {month}
            </Month>
          );
        })}
    </MonthBoard>
   ```


<br />


### 2️⃣ 페이지네이션 구현
- 페이지 별로 서버에 데이터를 요청할 예정이라 현재는 페이지네이션 틀만 잡아뒀습니당
- 특이사항은 없고, 클릭된 페이지에 조건부 스타일링 걸고 화살표 아이콘에 각각 핸들링 함수 걸어뒀습니다.