### PR TITLE
[ Solution ] 문제풀이 다시보기 리스트 컴포넌트 구현

### DIFF
--- a/src/components/Solution/List/Calendar.tsx
+++ b/src/components/Solution/List/Calendar.tsx
@@ -4,16 +4,15 @@ import { CalendarProps } from '../../../types/Solution/solutionTypes';
 
 const Calendar = ({
   date,
+  unsolvedMonths,
   handleClickPrevBtn,
   handleClickMonth,
   handleClickNextBtn,
 }: CalendarProps) => {
-  // 선택된 년도 별로 서버에서 받아올 예정 !
-  const dummy = [1, 3, 5, 10];
-
   const year = new Date().getFullYear();
   const { clickedYear, clickedMonth } = date;
   const monthCalendar = Array.from({ length: 12 }, (_, idx) => idx + 1);
+
   return (
     <CalendarContainer>
       <YearContainer>
@@ -24,7 +23,7 @@ const Calendar = ({
 
       <MonthBoard>
         {monthCalendar.map((month) => {
-          const disabled = dummy.includes(month) || clickedYear > year;
+          const disabled = unsolvedMonths.includes(month) || clickedYear > year;
           return (
             <Month
               key={month}

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import {
   IcArrowBottomWhite,
   IcArrowTopWhite,
   IcCalendar,
 } from '../../../assets';
+import { getUnsolvedMonths } from '../../../libs/apis/Solution/getUnsolvedMonths';
 import Calendar from './Calendar';
 
 const ListFilter = () => {
@@ -18,6 +19,7 @@ const ListFilter = () => {
     month: MONTH,
   });
   const [sorting, setSorting] = useState('최신순');
+  const unsolvedMonths = useRef<Array<number>>([]);
 
   const { year, month } = selectedDate;
 
@@ -54,6 +56,21 @@ const ListFilter = () => {
     // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
   };
 
+  const getUnsolvedMonthsArr = async () => {
+    try {
+      const { data } = await getUnsolvedMonths(year);
+      const { months } = data;
+
+      unsolvedMonths.current = months;
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    getUnsolvedMonthsArr();
+  }, [year]);
+
   return (
     <FilteredContainer>
       <DateFilterContainer>
@@ -68,6 +85,7 @@ const ListFilter = () => {
             <IcArrowTopWhite onClick={handleClickDateFilter} />
             <Calendar
               date={{ clickedYear: year, clickedMonth: month }}
+              unsolvedMonths={unsolvedMonths.current}
               handleClickPrevBtn={handleClickPrevBtn}
               handleClickMonth={handleClickMonth}
               handleClickNextBtn={handleClickNextBtn}

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -6,15 +6,8 @@ import {
   IcCalendar,
 } from '../../../assets';
 import { getUnsolvedMonths } from '../../../libs/apis/Solution/getUnsolvedMonths';
+import { ListFilterProps } from '../../../types/Solution/solutionTypes';
 import Calendar from './Calendar';
-
-interface ListFilterProps {
-  year: number;
-  month: number;
-  handleClickPrevBtn: (isPage: boolean) => void;
-  handleClickMonth: (value: number, isPage: boolean) => void;
-  handleClickNextBtn: (isPage: boolean) => void;
-}
 
 const ListFilter = ({
   year,

--- a/src/components/Solution/List/ListFilter.tsx
+++ b/src/components/Solution/List/ListFilter.tsx
@@ -8,44 +8,29 @@ import {
 import { getUnsolvedMonths } from '../../../libs/apis/Solution/getUnsolvedMonths';
 import Calendar from './Calendar';
 
-const ListFilter = () => {
+interface ListFilterProps {
+  year: number;
+  month: number;
+  handleClickPrevBtn: (isPage: boolean) => void;
+  handleClickMonth: (value: number, isPage: boolean) => void;
+  handleClickNextBtn: (isPage: boolean) => void;
+}
+
+const ListFilter = ({
+  year,
+  month,
+  handleClickPrevBtn,
+  handleClickMonth,
+  handleClickNextBtn,
+}: ListFilterProps) => {
   const LIST_SORTING = ['최신순', '|', '즐겨찾기'];
-  const YEAR = new Date().getFullYear();
-  const MONTH = new Date().getMonth() + 1;
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
-  const [selectedDate, setSelectedDate] = useState({
-    year: YEAR,
-    month: MONTH,
-  });
   const [sorting, setSorting] = useState('최신순');
   const unsolvedMonths = useRef<Array<number>>([]);
 
-  const { year, month } = selectedDate;
-
   const handleClickDateFilter = () => {
     setIsCalendarClicked(!isCalendarClicked);
-  };
-
-  const handleClickPrevBtn = () => {
-    setSelectedDate({
-      ...selectedDate,
-      year: year - 1,
-    });
-  };
-
-  const handleClickMonth = (month: number) => {
-    setSelectedDate({
-      ...selectedDate,
-      month: month,
-    });
-  };
-
-  const handleClickNextBtn = () => {
-    setSelectedDate({
-      ...selectedDate,
-      year: year + 1,
-    });
   };
 
   const handleClickSorting = (
@@ -86,9 +71,9 @@ const ListFilter = () => {
             <Calendar
               date={{ clickedYear: year, clickedMonth: month }}
               unsolvedMonths={unsolvedMonths.current}
-              handleClickPrevBtn={handleClickPrevBtn}
-              handleClickMonth={handleClickMonth}
-              handleClickNextBtn={handleClickNextBtn}
+              handleClickPrevBtn={() => handleClickPrevBtn(false)}
+              handleClickMonth={() => handleClickMonth(month, false)}
+              handleClickNextBtn={() => handleClickNextBtn(false)}
             />
           </>
         ) : (

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -75,10 +75,6 @@ const SavedSolutionList = () => {
     }
   };
 
-  useEffect(() => {
-    getMonthlySolutionList();
-  }, [totalPageRef, clickedPage]);
-
   const handleClickPrevBtn = (isPage: boolean) => {
     isPage
       ? setClickedPage((prev) => prev - 1)
@@ -108,7 +104,7 @@ const SavedSolutionList = () => {
 
   useEffect(() => {
     getMonthlySolutionList();
-  }, []);
+  }, [totalPageRef.current, clickedPage]);
 
   return (
     <ListContainer>

--- a/src/components/Solution/List/SavedSolutionList.tsx
+++ b/src/components/Solution/List/SavedSolutionList.tsx
@@ -74,49 +74,78 @@ const SAVED_DUMMY = {
 };
 
 const SavedSolutionList = () => {
-  const [clickedPage, setClickedPage] = useState(1);
-
   const { totalPage, records } = SAVED_DUMMY;
   const pages = Array.from({ length: totalPage }, (_, idx) => idx + 1);
+  const YEAR = new Date().getFullYear();
+  const MONTH = new Date().getMonth() + 1;
+
+  const [clickedPage, setClickedPage] = useState(1);
+  const [selectedDate, setSelectedDate] = useState({
+    year: YEAR,
+    month: MONTH,
+  });
+
+  const { year, month } = selectedDate;
 
   // 페이지 별 문제 리스트 요청 함수 추가할 예정 ! -> 페이지 이동 함수들에 들어갈 것임
 
-  const handleClickPrevBtn = () => {
-    setClickedPage((prev) => prev - 1);
+  const handleClickPrevBtn = (isPage: boolean) => {
+    isPage
+      ? setClickedPage((prev) => prev - 1)
+      : setSelectedDate({
+          ...selectedDate,
+          year: year - 1,
+        });
   };
 
-  const handleClickPageNumber = (page: number) => {
-    setClickedPage(page);
+  const handleClickValue = (value: number, isPage: boolean) => {
+    isPage
+      ? setClickedPage(value)
+      : setSelectedDate({
+          ...selectedDate,
+          month: month,
+        });
   };
 
-  const handleClickNextBtn = () => {
-    setClickedPage((prev) => prev + 1);
+  const handleClickNextBtn = (isPage: boolean) => {
+    isPage
+      ? setClickedPage((prev) => prev + 1)
+      : setSelectedDate({
+          ...selectedDate,
+          year: year + 1,
+        });
   };
 
   return (
     <ListContainer>
-      <ListFilter />
+      <ListFilter
+        year={year}
+        month={month}
+        handleClickPrevBtn={handleClickPrevBtn}
+        handleClickMonth={handleClickValue}
+        handleClickNextBtn={handleClickNextBtn}
+      />
       {records.map((record) => {
         return <SavedSolution key={record.recordId} record={record} />;
       })}
 
       <PageNationBar>
         <IcArrowLeftSmallGray
-          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
+          onClick={() => clickedPage !== 1 && handleClickPrevBtn(true)}
         />
         {pages.map((page) => {
           return (
             <PageNumber
               key={page}
               $isClicked={clickedPage === page}
-              onClick={() => handleClickPageNumber(page)}
+              onClick={() => handleClickValue(page, true)}
             >
               {page}
             </PageNumber>
           );
         })}
         <IcArrowRightSmallGray
-          onClick={() => clickedPage !== totalPage && handleClickNextBtn()}
+          onClick={() => clickedPage !== totalPage && handleClickNextBtn(true)}
         />
       </PageNationBar>
     </ListContainer>

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -1,0 +1,20 @@
+import { api } from '../../api';
+
+interface getMonthlySolutionProps {
+  year: number;
+  month: number;
+  page: number;
+}
+
+export const getMonthlySolution = async ({
+  year,
+  month,
+  page,
+}: getMonthlySolutionProps) => {
+  const userId = sessionStorage.getItem('user');
+  const { data } = await api.get(
+    `/records/${userId}/months?pivotDate=${year}-${month}-01&page=${page}&size=7`
+  );
+
+  return data;
+};

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -13,7 +13,7 @@ export const getMonthlySolution = async ({
 }: getMonthlySolutionProps) => {
   const userId = sessionStorage.getItem('user');
   const { data } = await api.get(
-    `/records/${userId}/months?pivotDate=${year}-${month}-01&page=${page}&size=7`
+    `/records/${userId}/month?pivotDate=${year}-0${month}-01&page=${page}&size=7`
   );
 
   return data;

--- a/src/libs/apis/Solution/getUnsolvedMonths.ts
+++ b/src/libs/apis/Solution/getUnsolvedMonths.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+export const getUnsolvedMonths = async (year: number) => {
+  const userId = sessionStorage.getItem('user');
+
+  const { data } = await api.get(
+    `/records/${userId}/unsolved-months?pivotDate=${year}-01-01`
+  );
+
+  return data;
+};

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -43,6 +43,7 @@ export interface CalendarProps {
     clickedYear: number;
     clickedMonth: number;
   };
+  unsolvedMonths: Array<number>;
   handleClickPrevBtn: () => void;
   handleClickMonth: (month: number) => void;
   handleClickNextBtn: () => void;

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -83,3 +83,11 @@ export interface UpdateSavedRecordsProps {
     ];
   };
 }
+
+export interface ListFilterProps {
+  year: number;
+  month: number;
+  handleClickPrevBtn: (isPage: boolean) => void;
+  handleClickMonth: (value: number, isPage: boolean) => void;
+  handleClickNextBtn: (isPage: boolean) => void;
+}

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -67,3 +67,19 @@ export interface UpdateRecordsProps {
     ];
   };
 }
+
+export interface UpdateSavedRecordsProps {
+  data: {
+    records: [
+      {
+        recordId: number;
+        title: string;
+        level: number;
+        tags: Array<string>;
+        platform: string;
+        problemUrl: string;
+        createdAt: string;
+      },
+    ];
+  };
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #111 

## ✅ 작업 내용

- [x] 문제풀이가 없는 달을 가져오는 api 연결
- [x] 선택된 달에 저장된 문제풀이를 가져오는 api 연결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/4c77d05a-5ff1-41b8-9646-1a0c43e81e9b


## 📌 이슈 사항
### 1️⃣ 문제풀이가 없는 달을 가져오는 api 연결
- 값 변경에 따른 리렌더링을 방지하기 위해 [🔗 useRef](https://ko.react.dev/reference/react/useRef) 를 활용했습니다.
- 년도가 바뀌면 문제풀이 없는 달을 다시 가져와야 하기 때문에 useEffect dependency로 year 값을 넣어줬어요
```typescript
 const getUnsolvedMonthsArr = async () => {
    try {
      const { data } = await getUnsolvedMonths(year);
      const { months } = data;

      unsolvedMonths.current = months;
    } catch (err) {
      console.log(err);
    }
  };

  useEffect(() => {
    getUnsolvedMonthsArr();
  }, [year]);
```

<br />

### 2️⃣ 선택된 달에 저장된 문제풀이를 가져오는 api 연결
- 선택된 달에 저장된 문제풀이 정보를 가져오는 api를 연결해서 안에 저장된 데이터로 각각 전체 페이지, 기록 state 값을 업데이트 했어요.
- 아래 함수 내부에 있는 updateTotalPage(), updateRecords() 함수는 TempSave.tsx와 거의 동일하게 구현했습니다 ! 
(#110 참고)
```typescript
  const getMonthlySolutionList = async () => {
    const { data } = await getMonthlySolution({
      year: year,
      month: month,
      page: clickedPage - 1,
    });

    updateTotalPage({ data });
    updateRecords({ data });
  };
```