### PR TITLE
[ MyGroup ] 내 그룹 뷰 퍼블리싱

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,6 +9,7 @@ import LoginPage from './page/LoginPage';
 import SolutionListPage from './page/SolutionListPage';
 import SolutionPage from './page/SolutionPage';
 import SolvePage from './page/SolvePage';
+import MyGroup from './page/MyGroup';
 
 const Router = () => {
   return (
@@ -18,7 +19,7 @@ const Router = () => {
         <Route path="/group" />
         <Route path="/group/:id" />
         <Route path="/group-new" element={<GroupCreate />} />
-        <Route path="/my-group" />
+        <Route path="/my-group" element={<MyGroup />}/>
         <Route path="/group-join" element={<GroupJoin />} />
         <Route path="/group-complete" element={<GroupComplete />} />
         <Route path="/solve" element={<SolvePage />} />

--- a/src/common/Groups.tsx
+++ b/src/common/Groups.tsx
@@ -1,0 +1,121 @@
+import React, { useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../assets';
+import { SORTING } from '../constants/Follower/currentConst';
+import { RecommendGroupProps } from '../types/MyGroup/myGroupType';
+import RecommendCard from './RecommendCard';
+
+const Groups = ({  group }: RecommendGroupProps) => {
+  // 일단 더미 데이터로 넣어둠, 서버 연결 시 0으로 초기화하고 서버에서 가져온 전체 페이지 데이터로 업데이트 예정
+  const totalPageRef = useRef(3);
+  const pages = Array.from(
+    { length: totalPageRef.current },
+    (_, idx) => idx + 1
+  );
+
+  const [sorting, setSorting] = useState('최신순');
+  const [clickedPage, setClickedPage] = useState(1);
+
+  const handleClickSorting = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
+  ) => {
+    const { innerHTML } = e.currentTarget;
+    setSorting(innerHTML);
+    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
+  };
+
+  const handleClickPrevBtn = () => {
+    setClickedPage((prev) => prev - 1);
+  };
+
+  const handleClickPage = (page: number) => {
+    setClickedPage(page);
+  };
+
+  const handleClickNextBtn = () => {
+    setClickedPage((prev) => prev + 1);
+  };
+
+  return (
+    <React.Fragment>
+      <SortContainer>
+        {SORTING.map((standard) => {
+          return (
+            <Sorting
+              key={standard}
+              onClick={(e) => standard !== '|' && handleClickSorting(e)}
+              $isClicked={sorting === standard}
+            >
+              {standard}
+            </Sorting>
+          );
+        })}
+      </SortContainer>
+
+      <RecommendCard group={group} isLongPage={true} />
+
+      <PageNationBar>
+        <IcArrowLeftSmallGray
+          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
+        />
+        {pages.map((page) => {
+          return (
+            <PageNumber
+              key={page}
+              $isClicked={clickedPage === page}
+              onClick={() => handleClickPage(page)}
+            >
+              {page}
+            </PageNumber>
+          );
+        })}
+        <IcArrowRightSmallGray
+          onClick={() =>
+            clickedPage !== totalPageRef.current && handleClickNextBtn()
+          }
+        />
+      </PageNationBar>
+    </React.Fragment>
+  );
+};
+
+export default Groups;
+
+const SortContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+`;
+
+const Sorting = styled.p<{ $isClicked: boolean }>`
+  color: ${({ $isClicked, theme }) =>
+    $isClicked ? theme.colors.white : theme.colors.gray500};
+  ${({ theme }) => theme.fonts.body_medium_14};
+`;
+
+const PageNationBar = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  margin-top: 4.8rem;
+`;
+
+const PageNumber = styled.p<{ $isClicked: boolean }>`
+  padding: 0.4rem 1rem;
+
+  border-radius: 0.4rem;
+  ${({ theme, $isClicked }) =>
+    $isClicked
+      ? css`
+          background-color: ${theme.colors.gray700};
+          color: ${theme.colors.white};
+        `
+      : css`
+          background-color: transparent;
+          color: ${theme.colors.gray200};
+        `};
+  ${({ theme }) => theme.fonts.body_medium_16};
+`;

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { RecommendCardProps } from '../types/GroupAll/RecommendCardType';
 
-const RecommendCard = ({ group }: RecommendCardProps) => {
+const RecommendCard = ({ group, isLongPage }: RecommendCardProps) => {
   const handleClickCard = (id: number) => {
     /* 페이지 이동 */
 
@@ -10,7 +10,7 @@ const RecommendCard = ({ group }: RecommendCardProps) => {
   };
 
   return (
-    <RecommendCardContainer>
+    <RecommendCardContainer $isLongPage={isLongPage} $numOfData={group.length}>
       {group.map((card) => {
         const { nickname, imgSrc, profile, num, title, content, tags } = card;
 
@@ -46,10 +46,17 @@ const RecommendCard = ({ group }: RecommendCardProps) => {
   );
 };
 
-const RecommendCardContainer = styled.article`
+const RecommendCardContainer = styled.article<{
+  $isLongPage: boolean;
+  $numOfData: number;
+}>`
   display: grid;
   gap: 4rem 1.8rem;
   grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: ${({ $isLongPage, $numOfData }) =>
+    $isLongPage && $numOfData >= 9
+      ? `repeat(3,1fr)`
+      : $numOfData >= 6 && `repeat(2, 1fr)`};
 
   width: 100%;
 

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -17,6 +17,7 @@ const RecommendCard = ({ group }: RecommendCardProps) => {
         return (
           <CardContainer key={num} onClick={() => handleClickCard(num)}>
             <Img src={imgSrc} />
+
             <Info>
               <CardHeader>
                 <UserImg src={profile} />
@@ -26,10 +27,12 @@ const RecommendCard = ({ group }: RecommendCardProps) => {
                   <p>{num} / 50명</p>
                 </TextId>
               </CardHeader>
+
               <CardBody>
                 <CardTitle>{title}</CardTitle>
                 <CardContent>{content}</CardContent>
               </CardBody>
+
               <CardTags>
                 {tags.map((tag) => (
                   <Tag key={tag}>{tag}</Tag>
@@ -58,9 +61,6 @@ const RecommendCardContainer = styled.article`
 const CardContainer = styled.div`
   display: flex;
   flex-direction: column;
-
-  width: 29.6rem;
-  height: 31rem;
 `;
 
 const Img = styled.img`

--- a/src/components/MyGroup/ActiveGroup.tsx
+++ b/src/components/MyGroup/ActiveGroup.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { IcArrowLeftFill, IcArrowRightFill } from '../../assets';
+import { ActiveGroupProps } from '../../types/MyGroup/myGroupType';
+
+const ActiveGroup = ({ item }: ActiveGroupProps) => {
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const itemsPerPage = 4;
+  const totalPages = Math.ceil(item.length / itemsPerPage);
+
+  const nextSlide = () => {
+    setCurrentSlide((prev) => (prev + 1) % totalPages);
+  };
+
+  const prevSlide = () => {
+    setCurrentSlide((prev) => (prev - 1 + totalPages) % totalPages);
+  };
+
+  const handleClickItem = (id: number) => {
+    console.log('click!', id);
+  };
+
+  return (
+    <ActiveGroupContainer>
+      <MainTitle>최근 활동 중인 그룹</MainTitle>
+
+      <CarouselContainer>
+        <CarouselButton $isHidden={currentSlide === 0} onClick={prevSlide}>
+          <IcArrowLeftFill />
+        </CarouselButton>
+        <CarouselWrapper>
+          <CarouselContent $currentSlide={currentSlide}>
+            {Array.from({ length: totalPages }, (_, index) => (
+              <CarouselSlide key={index}>
+                {item
+                  .slice(
+                    index * itemsPerPage,
+                    index * itemsPerPage + itemsPerPage
+                  )
+                  .map((card) => {
+                    const { id, tags, title, contents } = card;
+                    return (
+                      <CarouselItem
+                        key={id}
+                        onClick={() => handleClickItem(id)}
+                      >
+                        <TagContainer>
+                          {tags.map((tag, tagIndex) => (
+                            <Tag key={tagIndex}>{tag}</Tag>
+                          ))}
+                        </TagContainer>
+                        <Title>{title}</Title>
+                        <Introduce>{contents}</Introduce>
+                      </CarouselItem>
+                    );
+                  })}
+              </CarouselSlide>
+            ))}
+          </CarouselContent>
+        </CarouselWrapper>
+
+        <CarouselButton onClick={nextSlide}>
+          <IcArrowRightFill />
+        </CarouselButton>
+      </CarouselContainer>
+    </ActiveGroupContainer>
+  );
+};
+
+export default ActiveGroup;
+
+const ActiveGroupContainer = styled.div`
+  width: 100%;
+  max-width: 99.8rem;
+
+  margin: 0 auto;
+`;
+
+const CarouselContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+
+  width: 99.8rem;
+  margin: 0 auto;
+`;
+
+const MainTitle = styled.p`
+  margin-bottom: 3rem;
+  margin-left: 0.2rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_24};
+`;
+
+const CarouselWrapper = styled.div`
+  overflow: hidden;
+
+  width: 100%;
+`;
+
+const CarouselContent = styled.div<{ $currentSlide: number }>`
+  display: flex;
+  transition: transform 0.5s ease;
+  transform: ${({ $currentSlide }) => `translateX(-${$currentSlide * 100}%)`};
+`;
+
+const CarouselSlide = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-shrink: 0;
+
+  width: 100%;
+`;
+
+const CarouselItem = styled.div`
+  width: 22.3rem;
+  height: 14.5rem;
+  padding: 2.2rem 1.8rem;
+
+  border-radius: 1.2rem;
+  background-color: #333;
+  color: #fff;
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+const Tag = styled.p`
+  margin-bottom: 1.5rem;
+
+  color: ${({ theme }) => theme.colors.codrive_purple};
+
+  ${({ theme }) => theme.fonts.body_eng_medium_12};
+`;
+
+const Title = styled.div`
+  height: 3.4rem;
+  margin-bottom: 1.4rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_14};
+`;
+
+const Introduce = styled.div`
+  color: ${({ theme }) => theme.colors.gray300};
+  ${({ theme }) => theme.fonts.body_ligth_10};
+`;
+
+const CarouselButton = styled.button<{ $isHidden?: boolean }>`
+  visibility: ${({ $isHidden }) => ($isHidden ? 'hidden' : 'visible')};
+`;

--- a/src/components/MyGroup/ActiveGroups.tsx
+++ b/src/components/MyGroup/ActiveGroups.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { IcArrowLeftFill, IcArrowRightFill } from '../../assets';
 import { ActiveGroupProps } from '../../types/MyGroup/myGroupType';
 
-const ActiveGroup = ({ totalActiveGroups }: ActiveGroupProps) => {
+const ActiveGroups = ({ totalActiveGroups }: ActiveGroupProps) => {
   const currentPageRef = useRef(0);
   const isFirstPage = currentPageRef.current === 0;
   const isLastPage = currentPageRef.current === totalActiveGroups.length - 4;
@@ -67,7 +67,7 @@ const ActiveGroup = ({ totalActiveGroups }: ActiveGroupProps) => {
   );
 };
 
-export default ActiveGroup;
+export default ActiveGroups;
 
 const ActiveGroupContainer = styled.article`
   display: flex;

--- a/src/components/MyGroup/RecommendGroup.tsx
+++ b/src/components/MyGroup/RecommendGroup.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import RecommendCard from '../../common/RecommendCard';
+import { SORTING } from '../../constants/Follower/currentConst';
 import { RecommendGroupProps } from '../../types/MyGroup/myGroupType';
 
 const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
-  const [isClicked, setIsClicked] = useState('내가 참여한 그룹');
+  const GROUP_CATEGORY = ['내가 참여한 그룹', '내가 생성한 그룹'];
+
+  const [isClicked, setIsClicked] = useState(GROUP_CATEGORY[0]);
+  const [sorting, setSorting] = useState('최신순');
 
   const handleClickCategory = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
@@ -13,22 +17,44 @@ const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
     setIsClicked(innerHTML);
   };
 
+  const handleClickSorting = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
+  ) => {
+    const { innerHTML } = e.currentTarget;
+    setSorting(innerHTML);
+    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
+  };
+
   return (
     <Recommendcontainer>
       <RecommendHeader>
-        <Category
-          onClick={handleClickCategory}
-          $isClickedCategory={isClicked === '내가 참여한 그룹'}
-        >
-          내가 참여한 그룹
-        </Category>
-        <Category
-          onClick={handleClickCategory}
-          $isClickedCategory={isClicked === '내가 생성한 그룹'}
-        >
-          내가 생성한 그룹
-        </Category>
+        {GROUP_CATEGORY.map((category, idx) => {
+          return (
+            <Category
+              key={idx}
+              onClick={handleClickCategory}
+              $isClickedCategory={isClicked === category}
+            >
+              {category}
+            </Category>
+          );
+        })}
       </RecommendHeader>
+
+      <SortContainer>
+        {SORTING.map((standard) => {
+          return (
+            <Sorting
+              key={standard}
+              onClick={(e) => standard !== '|' && handleClickSorting(e)}
+              $isClicked={sorting === standard}
+            >
+              {standard}
+            </Sorting>
+          );
+        })}
+      </SortContainer>
+
       <RecommendCard user={user} group={group} />
     </Recommendcontainer>
   );
@@ -38,8 +64,9 @@ export default RecommendGroup;
 
 const Recommendcontainer = styled.article`
   display: flex;
-  gap: 3rem;
+  gap: 1.6rem;
   justify-content: center;
+  align-items: end;
   flex-direction: column;
 
   width: 100%;
@@ -70,4 +97,18 @@ const Category = styled.p<{ $isClickedCategory: boolean }>`
         `};
 
   ${({ theme }) => theme.fonts.title_medium_24};
+`;
+
+const SortContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+
+  margin-top: 0.2rem;
+`;
+
+const Sorting = styled.p<{ $isClicked: boolean }>`
+  color: ${({ $isClicked, theme }) =>
+    $isClicked ? theme.colors.white : theme.colors.gray500};
+  ${({ theme }) => theme.fonts.body_medium_14};
 `;

--- a/src/components/MyGroup/RecommendGroup.tsx
+++ b/src/components/MyGroup/RecommendGroup.tsx
@@ -1,48 +1,17 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
-import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
-import RecommendCard from '../../common/RecommendCard';
-import { SORTING } from '../../constants/Follower/currentConst';
+import Groups from '../../common/Groups';
 import { RecommendGroupProps } from '../../types/MyGroup/myGroupType';
 
-const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
+const RecommendGroup = ({ group }: RecommendGroupProps) => {
   const GROUP_CATEGORY = ['내가 참여한 그룹', '내가 생성한 그룹'];
-  // 일단 더미 데이터로 넣어둠, 서버 연결 시 0으로 초기화하고 서버에서 가져온 전체 페이지 데이터로 업데이트 예정
-  const totalPageRef = useRef(3);
-  const pages = Array.from(
-    { length: totalPageRef.current },
-    (_, idx) => idx + 1
-  );
-
   const [isClicked, setIsClicked] = useState(GROUP_CATEGORY[0]);
-  const [sorting, setSorting] = useState('최신순');
-  const [clickedPage, setClickedPage] = useState(1);
 
   const handleClickCategory = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
     setIsClicked(innerHTML);
-  };
-
-  const handleClickSorting = (
-    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
-  ) => {
-    const { innerHTML } = e.currentTarget;
-    setSorting(innerHTML);
-    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
-  };
-
-  const handleClickPrevBtn = () => {
-    setClickedPage((prev) => prev - 1);
-  };
-
-  const handleClickPage = (page: number) => {
-    setClickedPage(page);
-  };
-
-  const handleClickNextBtn = () => {
-    setClickedPage((prev) => prev + 1);
   };
 
   return (
@@ -61,43 +30,7 @@ const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
         })}
       </RecommendHeader>
 
-      <SortContainer>
-        {SORTING.map((standard) => {
-          return (
-            <Sorting
-              key={standard}
-              onClick={(e) => standard !== '|' && handleClickSorting(e)}
-              $isClicked={sorting === standard}
-            >
-              {standard}
-            </Sorting>
-          );
-        })}
-      </SortContainer>
-
-      <RecommendCard user={user} group={group} />
-
-      <PageNationBar>
-        <IcArrowLeftSmallGray
-          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
-        />
-        {pages.map((page) => {
-          return (
-            <PageNumber
-              key={page}
-              $isClicked={clickedPage === page}
-              onClick={() => handleClickPage(page)}
-            >
-              {page}
-            </PageNumber>
-          );
-        })}
-        <IcArrowRightSmallGray
-          onClick={() =>
-            clickedPage !== totalPageRef.current && handleClickNextBtn()
-          }
-        />
-      </PageNationBar>
+      <Groups group={group} />
     </Recommendcontainer>
   );
 };
@@ -121,6 +54,7 @@ const RecommendHeader = styled.header`
   align-items: center;
 
   width: 100%;
+  margin-bottom: 0.2rem;
 
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray700};
 `;
@@ -139,45 +73,4 @@ const Category = styled.p<{ $isClickedCategory: boolean }>`
         `};
 
   ${({ theme }) => theme.fonts.title_medium_24};
-`;
-
-const SortContainer = styled.div`
-  display: flex;
-  gap: 0.8rem;
-  align-items: center;
-
-  margin-top: 0.2rem;
-`;
-
-const Sorting = styled.p<{ $isClicked: boolean }>`
-  color: ${({ $isClicked, theme }) =>
-    $isClicked ? theme.colors.white : theme.colors.gray500};
-  ${({ theme }) => theme.fonts.body_medium_14};
-`;
-
-const PageNationBar = styled.div`
-  display: flex;
-  gap: 1.2rem;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  margin-top: 4.8rem;
-`;
-
-const PageNumber = styled.p<{ $isClicked: boolean }>`
-  padding: 0.4rem 1rem;
-
-  border-radius: 0.4rem;
-  ${({ theme, $isClicked }) =>
-    $isClicked
-      ? css`
-          background-color: ${theme.colors.gray700};
-          color: ${theme.colors.white};
-        `
-      : css`
-          background-color: transparent;
-          color: ${theme.colors.gray200};
-        `};
-  ${({ theme }) => theme.fonts.body_medium_16};
 `;

--- a/src/components/MyGroup/RecommendGroup.tsx
+++ b/src/components/MyGroup/RecommendGroup.tsx
@@ -1,14 +1,22 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
+import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
 import RecommendCard from '../../common/RecommendCard';
 import { SORTING } from '../../constants/Follower/currentConst';
 import { RecommendGroupProps } from '../../types/MyGroup/myGroupType';
 
 const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
   const GROUP_CATEGORY = ['내가 참여한 그룹', '내가 생성한 그룹'];
+  // 일단 더미 데이터로 넣어둠, 서버 연결 시 0으로 초기화하고 서버에서 가져온 전체 페이지 데이터로 업데이트 예정
+  const totalPageRef = useRef(3);
+  const pages = Array.from(
+    { length: totalPageRef.current },
+    (_, idx) => idx + 1
+  );
 
   const [isClicked, setIsClicked] = useState(GROUP_CATEGORY[0]);
   const [sorting, setSorting] = useState('최신순');
+  const [clickedPage, setClickedPage] = useState(1);
 
   const handleClickCategory = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
@@ -23,6 +31,18 @@ const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
     const { innerHTML } = e.currentTarget;
     setSorting(innerHTML);
     // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
+  };
+
+  const handleClickPrevBtn = () => {
+    setClickedPage((prev) => prev - 1);
+  };
+
+  const handleClickPage = (page: number) => {
+    setClickedPage(page);
+  };
+
+  const handleClickNextBtn = () => {
+    setClickedPage((prev) => prev + 1);
   };
 
   return (
@@ -56,6 +76,28 @@ const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
       </SortContainer>
 
       <RecommendCard user={user} group={group} />
+
+      <PageNationBar>
+        <IcArrowLeftSmallGray
+          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
+        />
+        {pages.map((page) => {
+          return (
+            <PageNumber
+              key={page}
+              $isClicked={clickedPage === page}
+              onClick={() => handleClickPage(page)}
+            >
+              {page}
+            </PageNumber>
+          );
+        })}
+        <IcArrowRightSmallGray
+          onClick={() =>
+            clickedPage !== totalPageRef.current && handleClickNextBtn()
+          }
+        />
+      </PageNationBar>
     </Recommendcontainer>
   );
 };
@@ -111,4 +153,31 @@ const Sorting = styled.p<{ $isClicked: boolean }>`
   color: ${({ $isClicked, theme }) =>
     $isClicked ? theme.colors.white : theme.colors.gray500};
   ${({ theme }) => theme.fonts.body_medium_14};
+`;
+
+const PageNationBar = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  margin-top: 4.8rem;
+`;
+
+const PageNumber = styled.p<{ $isClicked: boolean }>`
+  padding: 0.4rem 1rem;
+
+  border-radius: 0.4rem;
+  ${({ theme, $isClicked }) =>
+    $isClicked
+      ? css`
+          background-color: ${theme.colors.gray700};
+          color: ${theme.colors.white};
+        `
+      : css`
+          background-color: transparent;
+          color: ${theme.colors.gray200};
+        `};
+  ${({ theme }) => theme.fonts.body_medium_16};
 `;

--- a/src/components/MyGroup/RecommendGroup.tsx
+++ b/src/components/MyGroup/RecommendGroup.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import styled, { css } from 'styled-components';
+import RecommendCard from '../../common/RecommendCard';
+import { RecommendGroupProps } from '../../types/MyGroup/myGroupType';
+
+const RecommendGroup = ({ user, group }: RecommendGroupProps) => {
+  const [isClicked, setIsClicked] = useState('내가 참여한 그룹');
+
+  const handleClickCategory = (
+    e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
+  ) => {
+    const { innerHTML } = e.currentTarget;
+    setIsClicked(innerHTML);
+  };
+
+  return (
+    <Recommendcontainer>
+      <RecommendHeader>
+        <Category
+          onClick={handleClickCategory}
+          $isClickedCategory={isClicked === '내가 참여한 그룹'}
+        >
+          내가 참여한 그룹
+        </Category>
+        <Category
+          onClick={handleClickCategory}
+          $isClickedCategory={isClicked === '내가 생성한 그룹'}
+        >
+          내가 생성한 그룹
+        </Category>
+      </RecommendHeader>
+      <RecommendCard user={user} group={group} />
+    </Recommendcontainer>
+  );
+};
+
+export default RecommendGroup;
+
+const Recommendcontainer = styled.article`
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  flex-direction: column;
+
+  width: 100%;
+  padding: 0 4.2rem;
+`;
+
+const RecommendHeader = styled.header`
+  display: flex;
+  gap: 3.8rem;
+  align-items: center;
+
+  width: 100%;
+
+  border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray700};
+`;
+
+const Category = styled.p<{ $isClickedCategory: boolean }>`
+  padding-bottom: 1.2rem;
+
+  ${({ theme, $isClickedCategory }) =>
+    $isClickedCategory
+      ? css`
+          border-bottom: 0.2rem solid ${theme.colors.white};
+          color: ${({ theme }) => theme.colors.white};
+        `
+      : css`
+          color: ${({ theme }) => theme.colors.gray300};
+        `};
+
+  ${({ theme }) => theme.fonts.title_medium_24};
+`;

--- a/src/constants/MyGroup/myGroupConts.ts
+++ b/src/constants/MyGroup/myGroupConts.ts
@@ -1,0 +1,179 @@
+export const GROUP_ALL_DUMMY = {
+  item: [
+    {
+      id: 0,
+      tags: ['#javascript', '#kotlin', '#kotlin'],
+      title: `스터디 제목은 두 줄까지 가능`,
+      contents: `60자가 들어갈거같아용진자 어ㅣㄴ아러니아ㅓ리ㅏㅓ리ㅏ어리ㅏ너리나어리ㅏㄴ어리ㅏ너리ㅏㄴ러ㅣ아너린아ㅓ링ㄴ취우치나ㅜ치`,
+    },
+    {
+      id: 1,
+      tags: ['#javascript', '#data', '#AI'],
+      title: `데이터 분석 스터디`,
+      contents: `파이썬을 활용한 데이터 분석 및 AI 공부를 함께 합니다.`,
+    },
+    {
+      id: 2,
+      tags: ['#ALL', '#react', '#javascript'],
+      title: `프론트엔드 개발 스터디`,
+      contents: `React와 JavaScript로 프론트엔드 개발을 공부합니다.`,
+    },
+    {
+      id: 3,
+      tags: ['#backend', '#nodejs', '#express'],
+      title: `백엔드 개발 스터디`,
+      contents: `Node.js와 Express를 사용한 백엔드 개발을 다룹니다.`,
+    },
+    {
+      id: 4,
+      tags: ['#mobile', '#flutter', '#dart'],
+      title: `모바일 앱 개발 스터디`,
+      contents: `Flutter와 Dart로 모바일 앱 개발을 배웁니다.`,
+    },
+    {
+      id: 5,
+      tags: ['#devops', '#docker', '#javascript'],
+      title: `DevOps 스터디`,
+      contents: `Docker와 Kubernetes로 DevOps를 학습합니다.`,
+    },
+    {
+      id: 6,
+      tags: ['#ALL', '#kotlin', '#java'],
+      title: `코틀린과 자바 스터디`,
+      contents: `코틀린과 자바를 활용한 다양한 프로젝트를 진행합니다.`,
+    },
+    {
+      id: 7,
+      tags: ['#design', '#UI', '#UX'],
+      title: `UI/UX 디자인 스터디`,
+      contents: `사용자 경험과 인터페이스 디자인에 대해 공부합니다.`,
+    },
+    {
+      id: 8,
+      tags: ['#javascript', '#ALL', '#keras'],
+      title: `머신러닝 스터디`,
+      contents: `TensorFlow와 Keras를 사용한 머신러닝 프로젝트를 다룹니다.`,
+    },
+    {
+      id: 9,
+      tags: ['#cloud', '#aws', '#azure'],
+      title: `클라우드 컴퓨팅 스터디`,
+      contents: `AWS와 Azure를 사용한 클라우드 컴퓨팅을 배웁니다.`,
+    },
+    {
+      id: 10,
+      tags: ['#javascript', '#ALL', '#javascript'],
+      title: `보안 및 네트워크 스터디`,
+      contents: `네트워크 보안 및 암호화 기술을 학습합니다.`,
+    },
+    {
+      id: 11,
+      tags: ['#web', '#html', '#css'],
+      title: `웹 개발 기초 스터디`,
+      contents: `HTML과 CSS를 사용한 웹 개발 기초를 배웁니다.`,
+    },
+    {
+      id: 12,
+      tags: ['#game', '#unity', '#csharp'],
+      title: `게임 개발 스터디`,
+      contents: `Unity와 C#을 사용한 게임 개발을 다룹니다.`,
+    },
+    {
+      id: 13,
+      tags: ['#javascript', '#SQL', '#nosql'],
+      title: `데이터베이스 스터디`,
+      contents: `SQL과 NoSQL 데이터베이스를 공부합니다.`,
+    },
+    {
+      id: 14,
+      tags: ['#javascript', '#javascript', '#ALL'],
+      title: `알고리즘 및 자료구조 스터디`,
+      contents: `코딩 테스트 준비를 위한 알고리즘과 자료구조를 학습합니다.`,
+    },
+    {
+      id: 15,
+      tags: ['#javascript', '#javascript', '#ALL'],
+      title: `블록체인 개발 스터디`,
+      contents: `이더리움과 Solidity를 사용한 블록체인 개발을 다룹니다.`,
+    },
+  ],
+  user: '뭉주',
+  group: [
+    {
+      id: 0,
+      nickname: '김문주',
+      imgSrc:
+        'https://i.pinimg.com/originals/d5/c6/a8/d5c6a857172405b86184399a880f3886.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 12,
+      title: '누워있을 시간이 없습니다. 들어오세요',
+      tags: ['#JavaScript', '#React', '#CSS'],
+      content:
+        '누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요',
+    },
+    {
+      id: 1,
+      nickname: '서아름',
+      imgSrc:
+        'https://i.pinimg.com/564x/3f/e8/de/3fe8de19af99d28edcec4358e3f8561c.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 8,
+      title: '강남 그만 가자 모임 스터디',
+      tags: ['#Node.js', '#Express', '#MongoDB'],
+      content: '백엔드 개발을 같이 공부하는 모임입니다.',
+    },
+    {
+      id: 2,
+      nickname: '오승택',
+      imgSrc:
+        'https://i.pinimg.com/564x/54/3e/06/543e063d80e1d601886d60af8a09b968.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 11,
+      title: '어머어머 그래서 모임',
+      tags: ['#JavaScript', '#React', '#CSS'],
+      content: '함께 프론트엔드 개발을 공부하는 모임입니다.',
+    },
+    {
+      id: 3,
+      nickname: '김문주',
+      imgSrc:
+        'https://i.pinimg.com/originals/d5/c6/a8/d5c6a857172405b86184399a880f3886.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 1,
+      title: '누워있을 시간이 없습니다. 들어오세요',
+      tags: ['#JavaScript', '#React', '#CSS'],
+      content:
+        '누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요',
+    },
+    {
+      id: 4,
+      nickname: '김문주',
+      imgSrc:
+        'https://i.pinimg.com/originals/d5/c6/a8/d5c6a857172405b86184399a880f3886.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 2,
+      title: '누워있을 시간이 없습니다. 들어오세요',
+      tags: ['#JavaScript', '#React', '#CSS'],
+      content:
+        '누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요',
+    },
+    {
+      id: 5,
+      nickname: '김문주',
+      imgSrc:
+        'https://i.pinimg.com/originals/d5/c6/a8/d5c6a857172405b86184399a880f3886.jpg',
+      profile:
+        'https://i.pinimg.com/originals/f1/31/a9/f131a9d8f6d1851b3376ccca24230824.jpg',
+      num: 3,
+      title: '누워있을 시간이 없습니다. 들어오세요',
+      tags: ['#JavaScript', '#React', '#CSS'],
+      content:
+        '누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요누워있을 시간이 없습니다. 들어오세요',
+    },
+  ],
+};

--- a/src/page/GroupAllPage.tsx
+++ b/src/page/GroupAllPage.tsx
@@ -7,13 +7,14 @@ import { GROUP_ALL_DUMMY } from '../constants/GroupAll/groupAllConst';
 
 const GroupAllPage = () => {
   const { item, user, group } = GROUP_ALL_DUMMY;
+  
   return (
     <PageLayout category={'그룹'}>
       <GroupAllPageContainer>
         <TotalCard item={item} />
         <Recommendcontainer>
           <RecommendTitle user={user} />
-          <RecommendCard user={user} group={group} />
+          <RecommendCard group={group} isLongPage={false} />
         </Recommendcontainer>
       </GroupAllPageContainer>
     </PageLayout>

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -1,19 +1,18 @@
 import styled from 'styled-components';
-import RecommendCard from '../common/RecommendCard';
 import ActiveGroup from '../components/MyGroup/ActiveGroup';
+import RecommendGroup from '../components/MyGroup/RecommendGroup';
 import PageLayout from '../components/PageLayout/PageLayout';
 import { GROUP_ALL_DUMMY } from '../constants/MyGroup/myGroupConts';
 
 const GroupAllPage = () => {
   const { item, user, group } = GROUP_ALL_DUMMY;
+
   return (
     <PageLayout category={'그룹'}>
       <GroupAllPageContainer>
         <ActiveGroup totalActiveGroups={item} />
 
-        <Recommendcontainer>
-          <RecommendCard user={user} group={group} />
-        </Recommendcontainer>
+        <RecommendGroup user={user} group={group} />
       </GroupAllPageContainer>
     </PageLayout>
   );
@@ -26,14 +25,4 @@ const GroupAllPageContainer = styled.section`
   flex-direction: column;
 
   padding: 6rem 21.5rem 17.8rem;
-`;
-
-const Recommendcontainer = styled.section`
-  display: flex;
-  gap: 3rem;
-  justify-content: center;
-  flex-direction: column;
-
-  width: 100%;
-  padding: 0 4.2rem;
 `;

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -26,7 +26,7 @@ const GroupAllPageContainer = styled.section`
   align-items: center;
   flex-direction: column;
 
-  width: 100%;
+  padding: 6rem 21.5rem 17.8rem;
 `;
 
 const Recommendcontainer = styled.section`
@@ -36,5 +36,4 @@ const Recommendcontainer = styled.section`
   flex-direction: column;
 
   width: 100%;
-  padding: 7rem 25.7rem 21rem;
 `;

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import RecommendCard from '../common/RecommendCard';
+import RecommendTitle from '../components/GroupAll/RecommendTitle';
+import ActiveGroup from '../components/MyGroup/ActiveGroup';
+import PageLayout from '../components/PageLayout/PageLayout';
+import { GROUP_ALL_DUMMY } from '../constants/MyGroup/myGroupConts';
+
+const GroupAllPage = () => {
+  const { item, user, group } = GROUP_ALL_DUMMY;
+  return (
+    <PageLayout category={'그룹'}>
+      <GroupAllPageContainer>
+        <ActiveGroup item={item} />
+        <Recommendcontainer>
+          <RecommendTitle user={user} />
+          <RecommendCard user={user} group={group} />
+        </Recommendcontainer>
+      </GroupAllPageContainer>
+    </PageLayout>
+  );
+};
+export default GroupAllPage;
+
+const GroupAllPageContainer = styled.section`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+`;
+
+const Recommendcontainer = styled.section`
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  flex-direction: column;
+
+  width: 100%;
+  padding: 7rem 25.7rem 21rem;
+`;

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import ActiveGroup from '../components/MyGroup/ActiveGroup';
+import ActiveGroups from '../components/MyGroup/ActiveGroups';
 import RecommendGroup from '../components/MyGroup/RecommendGroup';
 import PageLayout from '../components/PageLayout/PageLayout';
 import { GROUP_ALL_DUMMY } from '../constants/MyGroup/myGroupConts';
@@ -10,7 +10,7 @@ const GroupAllPage = () => {
   return (
     <PageLayout category={'그룹'}>
       <GroupAllPageContainer>
-        <ActiveGroup totalActiveGroups={item} />
+        <ActiveGroups totalActiveGroups={item} />
 
         <RecommendGroup group={group} />
       </GroupAllPageContainer>

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -10,7 +10,8 @@ const GroupAllPage = () => {
   return (
     <PageLayout category={'그룹'}>
       <GroupAllPageContainer>
-        <ActiveGroup item={item} />
+        <ActiveGroup totalActiveGroups={item} />
+
         <Recommendcontainer>
           <RecommendTitle user={user} />
           <RecommendCard user={user} group={group} />

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import RecommendCard from '../common/RecommendCard';
-import RecommendTitle from '../components/GroupAll/RecommendTitle';
 import ActiveGroup from '../components/MyGroup/ActiveGroup';
 import PageLayout from '../components/PageLayout/PageLayout';
 import { GROUP_ALL_DUMMY } from '../constants/MyGroup/myGroupConts';
@@ -13,7 +12,6 @@ const GroupAllPage = () => {
         <ActiveGroup totalActiveGroups={item} />
 
         <Recommendcontainer>
-          <RecommendTitle user={user} />
           <RecommendCard user={user} group={group} />
         </Recommendcontainer>
       </GroupAllPageContainer>
@@ -37,4 +35,5 @@ const Recommendcontainer = styled.section`
   flex-direction: column;
 
   width: 100%;
+  padding: 0 4.2rem;
 `;

--- a/src/page/MyGroup.tsx
+++ b/src/page/MyGroup.tsx
@@ -5,14 +5,14 @@ import PageLayout from '../components/PageLayout/PageLayout';
 import { GROUP_ALL_DUMMY } from '../constants/MyGroup/myGroupConts';
 
 const GroupAllPage = () => {
-  const { item, user, group } = GROUP_ALL_DUMMY;
+  const { item, group } = GROUP_ALL_DUMMY;
 
   return (
     <PageLayout category={'그룹'}>
       <GroupAllPageContainer>
         <ActiveGroup totalActiveGroups={item} />
 
-        <RecommendGroup user={user} group={group} />
+        <RecommendGroup group={group} />
       </GroupAllPageContainer>
     </PageLayout>
   );

--- a/src/types/GroupAll/RecommendCardType.ts
+++ b/src/types/GroupAll/RecommendCardType.ts
@@ -1,5 +1,4 @@
 export interface RecommendCardProps {
-  user: string;
   group: Array<{
     nickname: string;
     imgSrc: string;
@@ -9,4 +8,5 @@ export interface RecommendCardProps {
     tags: Array<string>;
     content: string;
   }>;
+  isLongPage: boolean;
 }

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -1,0 +1,8 @@
+export interface ActiveGroupProps {
+  item: Array<{
+    id: number;
+    title: string;
+    contents: string;
+    tags: Array<string>;
+  }>;
+}

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -6,3 +6,16 @@ export interface ActiveGroupProps {
     tags: Array<string>;
   }>;
 }
+
+export interface RecommendGroupProps {
+  user: string;
+  group: Array<{
+    nickname: string;
+    imgSrc: string;
+    profile: string;
+    num: number;
+    title: string;
+    tags: Array<string>;
+    content: string;
+  }>;
+}

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -8,7 +8,6 @@ export interface ActiveGroupProps {
 }
 
 export interface RecommendGroupProps {
-  user: string;
   group: Array<{
     nickname: string;
     imgSrc: string;

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -1,5 +1,5 @@
 export interface ActiveGroupProps {
-  item: Array<{
+  totalActiveGroups: Array<{
     id: number;
     title: string;
     contents: string;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #13 

## ✅ 작업 내용

- [x] 페이지네이션 추가된 그룹 리스트 컴포넌트 공통 컴포넌트로 구현
- [x] 내 그룹 뷰 퍼블리싱

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/90cd4da2-1e37-4932-af2f-558d78fea3b5


## 📌 이슈 사항
### 1️⃣ RecommendCartd.tsx(공통 컴포넌트)에 분기처리를 위한 props 추가
- 변경된 홈 뷰에서는 요 공통 컴포넌트가 사용되지 않는줄 알았는데 홈에서도 사용이되길래 함께 사용할 수 있도록 isLongPage라는 props를 추가해서 해당 컴포넌트가 2*3, 3*3 레이아웃을 유지하도록 했어요.
- users라는 props는 전달만 될 뿐, 다른 컴포넌트에서 사용되지 않길래 props에서 제거해줬습니당

<br />

### 2️⃣ Groups 공통 컴포넌트 생성
- 내 그룹 뷰에서 쓰이는 페이지네이션이 적용된 그룹 리스트 컴포넌트가 홈 뷰에서도 쓰이더라구요!
- 함께 사용할 수 있도록 공통 컴포넌트로 만들어줬습니당 ~

<br />

### 3️⃣ 내 그룹 뷰 퍼블리싱
- 기존에 문주언니가 만들어준 컴포넌트를 그대로 가져와서 사용하려고 했는데, 디자인 상 조금 다른 부분도 있고 슬라이드 부분 로직이 잘 이해가 가지 않아서 조금 더 간단한 로직으로 구현해보았습니다 !
- 대신 언니가 기존에 만들어줬던 슬라이더 애니메이션을 그대로 사용하고 싶었는데 제가 변경한 코드에 적용하니까 잘 안되더라구요 ㅠ_ㅠ 조만간 다시 만져보겠습니다 !!