### PR TITLE
[ Group ] All 태그 선택 시 서버에 전달 안되는 현상

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -21,6 +21,7 @@ const Router = () => {
         <Route path="/my-group" />
         <Route path="/group-join" element={<GroupJoin />} />
         <Route path="/group-complete" element={<GroupComplete />} />
+        <Route path="/group-complete/:id" element={<GroupComplete />} />
         <Route path="/solve" element={<SolvePage />} />
         <Route path="/solution" element={<SolutionListPage />} />
         <Route path="/solution/:id" element={<SolutionPage />} />

--- a/src/common/CommonButton.tsx
+++ b/src/common/CommonButton.tsx
@@ -72,8 +72,8 @@ const IconContainer = styled.div`
 const BtnText = styled.p<{ $category: string; $isActive?: boolean }>`
   ${({ theme, $category }) =>
     $category === 'group_direct'
-      ? theme.fonts.title_bold_16
-      : theme.fonts.title_bold_20}
+      ? theme.fonts.title_bold_20
+      : theme.fonts.title_bold_16}
   color: ${({ theme, $isActive, $category }) => {
     if ($isActive || $category === 'group_direct') return theme.colors.gray900;
     return theme.colors.gray300;

--- a/src/components/GroupCreate/GroupSetting.tsx
+++ b/src/components/GroupCreate/GroupSetting.tsx
@@ -59,6 +59,7 @@ const Header = styled.h2`
 
 const Essential = styled.span`
   color: ${({ theme }) => theme.colors.codrive_purple};
+  ${({ theme }) => theme.fonts.title_medium_20};
 `;
 
 const ButtonContainer = styled.div`

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -10,6 +10,7 @@ const ALL_TAG = 'All';
 const LanguageSection = ({
   selectedTags,
   setSelectedTags,
+  onChangeTags,
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -21,15 +22,20 @@ const LanguageSection = ({
     if (selectedTags.length >= 5 && tag !== ALL_TAG) {
       return;
     }
-    if (tag === ALL_TAG) {
+
+    if (tag === 'ALL') {
       selectAllTags();
+      onChangeTags(DUMMY);
     } else {
+      // !
       if (!selectedTags.includes(tag)) {
         const newTags = selectedTags.includes(ALL_TAG)
           ? [...selectedTags.filter((t) => t !== ALL_TAG), tag]
           : [...selectedTags, tag];
         setSelectedTags(newTags);
+        onChangeTags(newTags);
 
+        // !
         if (newTags.length >= 5) {
           toggleDropdown();
         }
@@ -40,6 +46,7 @@ const LanguageSection = ({
   const removeTag = (tag: string) => {
     if (tag === ALL_TAG) {
       setSelectedTags([]);
+      // console.log(selectedTags);
     } else {
       setSelectedTags(selectedTags.filter((t) => t !== tag));
     }
@@ -47,6 +54,7 @@ const LanguageSection = ({
 
   const selectAllTags = () => {
     const allTags = [...DUMMY, ALL_TAG];
+    // setSelectedTags([...DUMMY, ALL_TAG]);
     setSelectedTags(allTags);
     toggleDropdown(); // 드롭다운 닫기
   };

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -2,17 +2,15 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { IcArrowBottomGray } from '../../assets';
 import CommonHashTag from '../../common/CommonHashTag';
-import { DUMMY } from '../../constants/GroupCreate/LanguageConst';
+import { ALL_TAG, DUMMY } from '../../constants/GroupCreate/LanguageConst';
 import { LanguageSectionProps } from '../../types/GroupCreate/GroupCreateType';
-
-const ALL_TAG = 'All';
 
 const LanguageSection = ({
   selectedTags,
   setSelectedTags,
-  onChangeTags,
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isAllSelected, setIsAllSelected] = useState(false);
 
   const toggleDropdown = () => {
     setIsDropdownOpen((prev) => !prev);
@@ -22,19 +20,17 @@ const LanguageSection = ({
     if (selectedTags.length >= 5 && tag !== ALL_TAG) {
       return;
     }
-
-    if (tag === 'ALL') {
-      selectAllTags();
-      onChangeTags(DUMMY);
+    if (tag === ALL_TAG) {
+      setIsAllSelected(true);
+      setSelectedTags(DUMMY);
     } else {
-      // !
       if (!selectedTags.includes(tag)) {
-        const newTags = selectedTags.includes(ALL_TAG)
-          ? [...selectedTags.filter((t) => t !== ALL_TAG), tag]
-          : [...selectedTags, tag];
+        // const newTags = selectedTags.includes(ALL_TAG)
+        //   ? [...selectedTags.filter((t) => t !== ALL_TAG), tag]
+        //   : [...selectedTags, tag];
+        const newTags = [...selectedTags, tag];
         setSelectedTags(newTags);
-        onChangeTags(newTags);
-
+        // onChangeTags(newTags);
         // !
         if (newTags.length >= 5) {
           toggleDropdown();
@@ -45,17 +41,17 @@ const LanguageSection = ({
 
   const removeTag = (tag: string) => {
     if (tag === ALL_TAG) {
+      setIsAllSelected(false);
       setSelectedTags([]);
-      // console.log(selectedTags);
+      console.log(selectedTags);
     } else {
       setSelectedTags(selectedTags.filter((t) => t !== tag));
     }
   };
 
   const selectAllTags = () => {
-    const allTags = [...DUMMY, ALL_TAG];
-    // setSelectedTags([...DUMMY, ALL_TAG]);
-    setSelectedTags(allTags);
+    setIsAllSelected(true);
+    setSelectedTags(DUMMY);
     toggleDropdown(); // 드롭다운 닫기
   };
 
@@ -66,7 +62,7 @@ const LanguageSection = ({
       </Label>
       <DropdownContainer onClick={toggleDropdown}>
         <div>
-          {selectedTags.includes(ALL_TAG) ? (
+          {isAllSelected ? (
             <SelectedTagContainer key={ALL_TAG}>
               <CommonHashTag
                 selectedTag={ALL_TAG}
@@ -95,10 +91,7 @@ const LanguageSection = ({
       </DropdownContainer>
       {isDropdownOpen && (
         <DropdownItemContainer>
-          <DropdownItem
-            $isSelected={selectedTags.includes(ALL_TAG)}
-            onClick={selectAllTags}
-          >
+          <DropdownItem $isSelected={isAllSelected} onClick={selectAllTags}>
             {ALL_TAG}
           </DropdownItem>
           <Borderline />

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -11,7 +11,6 @@ const LanguageSection = ({
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isAllSelected, setIsAllSelected] = useState(false);
-
   const toggleDropdown = () => {
     setIsDropdownOpen((prev) => !prev);
   };
@@ -25,13 +24,8 @@ const LanguageSection = ({
       setSelectedTags(DUMMY);
     } else {
       if (!selectedTags.includes(tag)) {
-        // const newTags = selectedTags.includes(ALL_TAG)
-        //   ? [...selectedTags.filter((t) => t !== ALL_TAG), tag]
-        //   : [...selectedTags, tag];
         const newTags = [...selectedTags, tag];
         setSelectedTags(newTags);
-        // onChangeTags(newTags);
-        // !
         if (newTags.length >= 5) {
           toggleDropdown();
         }
@@ -52,7 +46,7 @@ const LanguageSection = ({
   const selectAllTags = () => {
     setIsAllSelected(true);
     setSelectedTags(DUMMY);
-    toggleDropdown(); // 드롭다운 닫기
+    toggleDropdown();
   };
 
   return (

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { IcArrowBottomGray } from '../../assets';
+import { IcArrowBottomGray, IcArrowTopGray } from '../../assets';
 import CommonHashTag from '../../common/CommonHashTag';
 import { ALL_TAG, DUMMY } from '../../constants/GroupCreate/LanguageConst';
 import { LanguageSectionProps } from '../../types/GroupCreate/GroupCreateType';
@@ -11,6 +11,7 @@ const LanguageSection = ({
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isAllSelected, setIsAllSelected] = useState(false);
+
   const toggleDropdown = () => {
     setIsDropdownOpen((prev) => !prev);
   };
@@ -80,7 +81,7 @@ const LanguageSection = ({
           )}
         </div>
         <IconContainer>
-          <IcArrowBottomGray />
+          {isDropdownOpen ? <IcArrowTopGray /> : <IcArrowBottomGray />}
         </IconContainer>
       </DropdownContainer>
       {isDropdownOpen && (
@@ -143,7 +144,8 @@ const DropdownContainer = styled.div`
 
   width: 100%;
   height: 4.8rem;
-  padding: 1.5rem 2rem 1.4rem;
+  padding: 1.5rem 1.2rem 1.4rem 2rem;
+  margin-bottom: 0.6rem;
 
   border-radius: 0.8rem;
   background-color: ${({ theme }) => theme.colors.gray700};
@@ -189,8 +191,6 @@ const DropdownItem = styled.div<{ $isSelected: boolean }>`
 const IconContainer = styled.div`
   display: flex;
   align-items: center;
-
-  margin-right: 1.2rem;
 `;
 
 const DropdownText = styled.p`

--- a/src/constants/GroupCreate/LanguageConst.tsx
+++ b/src/constants/GroupCreate/LanguageConst.tsx
@@ -11,3 +11,5 @@ export const DUMMY = [
   'Scala',
   'Go',
 ];
+
+export const ALL_TAG = 'ALL';

--- a/src/constants/GroupCreate/LanguageConst.tsx
+++ b/src/constants/GroupCreate/LanguageConst.tsx
@@ -1,13 +1,13 @@
 export const DUMMY = [
   'Python',
   'Java',
-  'C',
-  'C++',
-  'C#',
   'Javascript',
+  'C++',
+  'C',
+  'C#',
   'Kotlin',
-  'Ruby',
   'Swift',
+  'Ruby',
   'Scala',
   'Go',
 ];

--- a/src/libs/apis/GroupComplete/getGroupInfo.ts
+++ b/src/libs/apis/GroupComplete/getGroupInfo.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+export const getGroupInfo = async (uuid: string) => {
+  try {
+    const response = await api.get(`rooms/uuid/${uuid}`);
+    const { data } = response.data;
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/libs/apis/GroupCreate/postGroupInfo.ts
+++ b/src/libs/apis/GroupCreate/postGroupInfo.ts
@@ -1,0 +1,14 @@
+import { api } from '../../api';
+
+export const postGroupInfo = async (requestBody: FormData) => {
+  try {
+    const { data } = await api.post('/rooms', requestBody, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -1,19 +1,40 @@
-import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonButton from '../common/CommonButton';
 import Modal from '../common/Modal/Modal';
 import PageLayout from '../components/PageLayout/PageLayout';
+import { getGroupInfo } from '../libs/apis/GroupComplete/getGroupInfo';
 import { handleCopyClipBoard } from '../utils/handleCopyClipBoard';
 
 const GroupComplete = () => {
   const navigate = useNavigate();
-  const { state } = useLocation();
-  const { groupPassword, thumbnailUrl } = state || {};
-  const baseUrl = window.location.origin; // 생성한 그룹 페이지가 만들어지면 대체 될 예정
+  const [groupPassword, setGroupPassword] = useState('');
+  const [thumbnailUrl, setThumbnailUrl] = useState('');
   const [isCopied, setIsCopied] = useState(false);
+  const { id: uuid } = useParams();
+  const token = sessionStorage.getItem('token');
+  const nickname = sessionStorage.getItem('nickname');
+
+  useEffect(() => {
+    if (token && nickname) {
+      const fetchGroupInfo = async () => {
+        try {
+          const data = await getGroupInfo(uuid!);
+          setGroupPassword(data.password);
+          setThumbnailUrl(data.imageSrc);
+        } catch (error) {
+          console.log('error');
+        }
+      };
+      fetchGroupInfo();
+    } else {
+      navigate('/login');
+    }
+  }, [uuid, token, nickname]);
 
   const handleClickCopyBtn = () => {
+    const baseUrl = window.location.origin; // 생성한 그룹 페이지가 만들어지면 대체 될 예정
     handleCopyClipBoard({ baseUrl: baseUrl, isUsedBaseUrl: true });
     setIsCopied(true);
     setTimeout(() => {

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -71,6 +71,7 @@ const GroupCreate = () => {
     group !== '';
 
   const handleGroupCreate = async () => {
+    // const cleanedTags = selectedTags.includes(ALL_TAG) ? DUMMY : selectedTags;
     const postData = {
       title: title,
       password: secretKey,
@@ -104,11 +105,7 @@ const GroupCreate = () => {
       console.log(error);
     }
   };
-
-  const handleOnChangeTags = (newTags: string[]) => {
-    setSelectedTags(newTags);
-    console.log(newTags);
-  };
+  console.log(selectedTags);
 
   return (
     <PageLayout category="그룹">
@@ -131,7 +128,6 @@ const GroupCreate = () => {
           handleMemberCountChange={handleChangeInputs}
         />
         <LanguageSection
-          onChangeTags={handleOnChangeTags}
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}
         />

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -12,7 +12,6 @@ import PageLayout from '../components/PageLayout/PageLayout';
 import { postGroupInfo } from '../libs/apis/GroupCreate/postGroupInfo';
 
 const GroupCreate = () => {
-  // 상태 객체 선언
   const [inputs, setInputs] = useState({
     title: '',
     num: '',
@@ -71,7 +70,6 @@ const GroupCreate = () => {
     group !== '';
 
   const handleGroupCreate = async () => {
-    // const cleanedTags = selectedTags.includes(ALL_TAG) ? DUMMY : selectedTags;
     const postData = {
       title: title,
       password: secretKey,

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -77,6 +77,11 @@ const GroupCreate = () => {
     });
   };
 
+  const handleOnChangeTags = (newTags: string[]) => {
+    setSelectedTags(newTags);
+    console.log(newTags);
+  };
+
   return (
     <PageLayout category="그룹">
       <Form>
@@ -98,6 +103,7 @@ const GroupCreate = () => {
           handleMemberCountChange={handleChangeInputs}
         />
         <LanguageSection
+          onChangeTags={handleOnChangeTags}
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}
         />

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -22,13 +22,11 @@ const GroupCreate = () => {
   });
 
   const [isPublicGroup, setIspublicGroup] = useState(false);
-  // const [isActive, setIsActive] = useState(false);
   const [previewImage, setPreviewImage] = useState<string | null>('');
   const [selectdImageFile, setSelctedImageFIle] = useState<File | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const navigate = useNavigate();
   const { title, num, secretKey, intro, group } = inputs;
-  // const isActive = title && num && secretKey && intro && group;
 
   const handleChangeInputs = <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.ChangeEvent<T>
@@ -64,14 +62,6 @@ const GroupCreate = () => {
       e.target.value = '';
     }
   };
-
-  // 모든 데이터가 채워지면 그룹버튼 생성 활성화
-  // useEffect(() => {
-  //   const allFieldsFilled = (
-  //     Object.keys(inputs) as Array<keyof typeof inputs>
-  //   ).every((key) => key === 'secretKey' || inputs[key] !== '');
-  //   setIsActive(allFieldsFilled || (isPublicGroup && allFieldsFilled));
-  // }, [inputs, isPublicGroup]);
 
   const isActive =
     title !== '' &&

--- a/src/types/GroupCreate/GroupCreateType.tsx
+++ b/src/types/GroupCreate/GroupCreateType.tsx
@@ -28,7 +28,6 @@ export interface IntroSectionProps {
 export interface LanguageSectionProps {
   selectedTags: string[];
   setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>;
-  onChangeTags: (tags: string[]) => void;
 }
 
 export interface TitleSectionProps {

--- a/src/types/GroupCreate/GroupCreateType.tsx
+++ b/src/types/GroupCreate/GroupCreateType.tsx
@@ -28,6 +28,7 @@ export interface IntroSectionProps {
 export interface LanguageSectionProps {
   selectedTags: string[];
   setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>;
+  onChangeTags: (tags: string[]) => void;
 }
 
 export interface TitleSectionProps {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #132 

## ✅ 작업 내용

- [x] All 태그 선택 시 서버에 모든 언어 전달

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/1ff81484-13cf-4fa5-947d-76d0b164969f

## 📌 이슈 사항

### 1️⃣ All 선택 시 모든 언어 담기

All 선택 시 'ALL' 이라는 string 도 함께 들어가서 서버로 전송이 되지 않았던 것이였어요 !

![image](https://github.com/user-attachments/assets/5baa2432-141b-4b3e-a545-754dc84d5762)

```const [isAllSelected, setIsAllSelected] = useState(false);```
때문에 all 을 선택을 한지 안한지 구분하려는 state를 하나 추가하여 만들어 주었습니다. 사실 이게 맞는건지도 아직 잘 모르겠긴 하는데,, PR로 남겨주시면 감사하겠습니다


selectAllTag 라는 함수를 하나 생성하여 현재 담겨있는 태그에 모든 언어들을 넣어주고 드롭다운을 시킵니다.

```jsx
const selectAllTags = () => {
    setIsAllSelected(true);
    setSelectedTags(DUMMY);
    toggleDropdown();
  };
  
```

그 다음 isAllSelected 가 true 이면 ALLTAG 가 담겨있는 태그가 UI로 나오게 되면서 변경해주었습니다.

```jsx
   {isAllSelected ? (
            <SelectedTagContainer key={ALL_TAG}>
              <CommonHashTag
                selectedTag={ALL_TAG}
                removeTag={() => removeTag(ALL_TAG)}
              />
            </SelectedTagContainer>
          ) 
```

서버에 전달되는 값 중 'ALL'이라는 string이 들어간지도 모르고 계속 해메고 있었네요,,

## ✍ 궁금한 것

커밋이 좀 많아졌는데 원래 feat/group -> develop 에서 한 작업들을 feat/common 으로 pull 받고 난 후 브랜치 분기를 하였는데 .. 왜 커밋이 또 들어갔는지 이유를 모르겠네요 
