### PR TITLE
Profile/#135 basic info form

### DIFF
--- a/src/components/MyProfile/BasicInfo.tsx
+++ b/src/components/MyProfile/BasicInfo.tsx
@@ -35,20 +35,77 @@ const BasicInfo = () => {
   );
 };
 
-const BasicInfoContainer = styled.article``;
+const BasicInfoContainer = styled.article`
+  width: 61.1rem;
+  height: 26.8rem;
+  padding: 2.4rem 2rem;
 
-const BasicTitle = styled.h2``;
+  background-color: ${({ theme }) => theme.colors.gray800};
+`;
 
-const NameContainer = styled.div``;
+const BasicTitle = styled.h2`
+  margin-bottom: 4rem;
 
-const NameTitle = styled.article``;
+  color: ${({ theme }) => theme.colors.white};
 
-const Name = styled.article``;
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
 
-const GitHubContainer = styled.div``;
+const NameContainer = styled.section`
+  display: flex;
+  align-items: center;
 
-const GitHubTitle = styled.article``;
+  padding: 1.45rem 0 2.85rem 1.6rem;
+  margin-bottom: 3.2rem;
 
-const Github = styled.p``;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
 
+const NameTitle = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Name = styled.p`
+  margin-left: 8.6rem;
+
+  color: ${({ theme }) => theme.colors.gray100};
+
+  ${({ theme }) => theme.fonts.body_medium_16};
+`;
+
+const GitHubContainer = styled.section`
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  padding: 0 0 1.4rem 1.6rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const GitHubTitle = styled.p`
+  margin-right: 3rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Github = styled.p`
+  overflow: hidden;
+
+  width: 31rem;
+  padding: 1.2rem 1.1rem;
+
+  color: ${({ theme }) => theme.colors.gray100};
+
+  word-break: break-all;
+
+  text-overflow: ellipsis;
+
+  ${({ theme }) => theme.fonts.body_medium_16};
+
+  white-space: nowrap;
+`;
 export default BasicInfo;

--- a/src/components/MyProfile/BasicInfo.tsx
+++ b/src/components/MyProfile/BasicInfo.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import CommonInput from '../../common/CommonInput';
+import EditButton from './EditButton';
+
+const BasicInfo = () => {
+  const [github, setGithub] = useState('');
+  const [isEditingGithub, setIsEditingGithub] = useState(false);
+
+  const handleEditClick = () => {
+    setIsEditingGithub(!isEditingGithub);
+  };
+
+  return (
+    <BasicInfoContainer>
+      <BasicTitle>기본정보</BasicTitle>
+      <NameContainer>
+        <NameTitle>이름</NameTitle>
+        <Name>서아름</Name>
+      </NameContainer>
+      <GitHubContainer>
+        <GitHubTitle>깃허브 주소</GitHubTitle>
+        {isEditingGithub ? (
+          <CommonInput
+            category="github"
+            value={github}
+            handleChangeInputs={(e) => setGithub(e.target.value)}
+          />
+        ) : (
+          <Github>https://github.com/{github}</Github>
+        )}
+        <EditButton isEditing={isEditingGithub} onClick={handleEditClick} />
+      </GitHubContainer>
+    </BasicInfoContainer>
+  );
+};
+
+const BasicInfoContainer = styled.article``;
+
+const BasicTitle = styled.h2``;
+
+const NameContainer = styled.div``;
+
+const NameTitle = styled.article``;
+
+const Name = styled.article``;
+
+const GitHubContainer = styled.div``;
+
+const GitHubTitle = styled.article``;
+
+const Github = styled.p``;
+
+export default BasicInfo;

--- a/src/components/MyProfile/EditButton.tsx
+++ b/src/components/MyProfile/EditButton.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+interface EditButtonProps {
+  isEditing?: boolean;
+  onClick: () => void;
+}
+
+const EditButton = ({ isEditing, onClick }: EditButtonProps) => {
+  return (
+    <Button $isEditing={isEditing} onClick={onClick}>
+      {isEditing ? '저장' : '수정'}
+    </Button>
+  );
+};
+
+const Button = styled.button<{ $isEditing?: boolean }>`
+  position: absolute;
+  right: 0;
+
+  width: 6.8rem;
+  height: 4.8rem;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme, $isEditing }) =>
+    $isEditing ? theme.colors.codrive_green : theme.colors.gray600};
+  color: ${({ theme, $isEditing }) =>
+    $isEditing ? theme.colors.gray900 : theme.colors.white};
+  font-size: ${({ theme, $isEditing }) =>
+    $isEditing ? theme.fonts.title_bold_16 : theme.fonts.body_ligth_16};
+
+  text-align: center;
+`;
+
+export default EditButton;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #135 

## ✅ 작업 내용

- [x] 내 프로필 뷰 (**기본정보**, ~~코드라이브 정보~~) 
- [x] 내 프로필 뷰에서만 사용하는 버튼 구현

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/e4bffce0-e29c-4a4e-a307-421561332b17


## 📌 이슈 사항
**내 프로필 뷰는 기본정보와 코드라이브 정보로 나뉘어 있습니다!! 둘 다 한번에 구현하기 나누는게 나을 거 같아서 분기처리 했습니다!**
## 1️⃣ 저장 버튼 
- 저장 버튼이 각 input, textarea 마다 사용되고 있어서 따로 빼서 구현했습니다!
```
const EditButton = ({ isEditing, onClick }: EditButtonProps) => {
  return (
    <Button $isEditing={isEditing} onClick={onClick}>
      {isEditing ? '저장' : '수정'}
    </Button>
  );
};
```
## 2️⃣ 기본 정보 컴포넌트
- isEditingGithub가 true인 경우: CommonInput 컴포넌트를 렌더링하고, 현재 github 상태 값을 value로 설정하며, 입력 값이 변경될 때 setGithub을 호출합니다.
- isEditingGithub가 false인 경우: Github 컴포넌트 안에 `https://github.com/{github}` 이라는 URL을 표시합니다. {github}는 현재 상태 값입니다.
```
  {isEditingGithub ? (
          <CommonInput
            category="github"
            value={github}
            handleChangeInputs={(e) => setGithub(e.target.value)}
          />
        ) : (
          <Github>https://github.com/{github}</Github>
        )}

## ✍ 궁금한 것
input에 text가 넘치면 말줄임 표시로 구현을 했는데... center로 고정이 돼있어서 그런지 ... 도같이 고정이 돼서 나오는데 스타일을 어떻게 변경해야 할까요?