### PR TITLE
[ MyProfile ] 내 프로필 뷰 퍼블리싱

### DIFF
--- a/src/common/CommonButton.tsx
+++ b/src/common/CommonButton.tsx
@@ -50,6 +50,8 @@ const Button = styled.button<{ $category: string; $isActive?: boolean }>`
         return '1.4rem 1.8rem 1.4rem 2.1rem';
       case 'link_copy':
         return '1rem 2rem';
+      case 'Profile_save':
+        return '1rem 2rem';
       default:
         return '1.2rem 5.4rem';
     }

--- a/src/components/Profile/GIthubInfo.tsx
+++ b/src/components/Profile/GIthubInfo.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import CommonInput from './../../common/CommonInput';
+
+const GithubInfo = ({ github, handleChangeInputs }) => {
+  return (
+    <GithubInfoContainer>
+      <GitHubTitle>깃허브 주소</GitHubTitle>
+      <CommonInput
+        category="github"
+        value={github}
+        handleChangeInputs={handleChangeInputs}
+      />
+    </GithubInfoContainer>
+  );
+};
+
+const GithubInfoContainer = styled.section`
+  display: flex;
+  align-items: center;
+
+  padding-bottom: 1.4rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const GitHubTitle = styled.p`
+  margin-right: 4.8rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+export default GithubInfo;

--- a/src/components/Profile/GIthubInfo.tsx
+++ b/src/components/Profile/GIthubInfo.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
+import { GithubInfoProps } from '../../types/Profile/ProfileType';
 import CommonInput from './../../common/CommonInput';
 
-const GithubInfo = ({ github, handleChangeInputs }) => {
+const GithubInfo = ({ github, handleChangeInputs }: GithubInfoProps) => {
   return (
     <GithubInfoContainer>
       <GitHubTitle>깃허브 주소</GitHubTitle>
@@ -23,7 +24,7 @@ const GithubInfoContainer = styled.section`
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
-const GitHubTitle = styled.p`
+const GitHubTitle = styled.h2`
   margin-right: 4.8rem;
 
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/Profile/IntroInfo.tsx
+++ b/src/components/Profile/IntroInfo.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import styled from 'styled-components';
+import { IntroInfoProps } from '../../types/Profile/ProfileType';
 import { handleInput } from '../../utils/handleInput';
 
-const IntroInfo = ({ value, onChange }) => {
+const IntroInfo = ({ value, onChange }: IntroInfoProps) => {
   const [hasError, setHasError] = useState(false);
   const maxLength = 30;
 
@@ -26,17 +27,18 @@ const IntroInfo = ({ value, onChange }) => {
   );
 };
 
-const IntroInfoContainer = styled.div`
+const IntroInfoContainer = styled.section`
   display: flex;
   align-items: center;
 
   padding-bottom: 1.4rem;
+  margin-bottom: 3.2rem;
 
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
 const IntroTitle = styled.h2`
-  margin-right: 4.8rem;
+  margin-right: 5.9rem;
 
   color: ${({ theme }) => theme.colors.white};
 
@@ -44,8 +46,8 @@ const IntroTitle = styled.h2`
 `;
 
 const Intro = styled.textarea<{ $hasError: boolean }>`
-  width: 100%;
-  padding: 1.4rem 2rem;
+  width: 29.6rem;
+  padding: 1.5rem 2rem;
   resize: none;
 
   ${({ theme }) => theme.fonts.body_ligth_16};

--- a/src/components/Profile/IntroInfo.tsx
+++ b/src/components/Profile/IntroInfo.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { handleInput } from '../../utils/handleInput';
+
+const IntroInfo = ({ value, onChange }) => {
+  const [hasError, setHasError] = useState(false);
+  const maxLength = 30;
+
+  const handleChangeIntro = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    handleInput(e, 'intro');
+    const { value } = e.target;
+    value.length > maxLength ? setHasError(true) : setHasError(false);
+    onChange(e);
+  };
+
+  return (
+    <IntroInfoContainer>
+      <IntroTitle>한 줄 소개</IntroTitle>
+      <Intro
+        value={value}
+        onChange={handleChangeIntro}
+        $hasError={hasError}
+        placeholder="나를 소개하는 문구를 적어주세요."
+      />
+    </IntroInfoContainer>
+  );
+};
+
+const IntroInfoContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  padding-bottom: 1.4rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const IntroTitle = styled.h2`
+  margin-right: 4.8rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Intro = styled.textarea<{ $hasError: boolean }>`
+  width: 100%;
+  padding: 1.4rem 2rem;
+  resize: none;
+
+  ${({ theme }) => theme.fonts.body_ligth_16};
+  border: 1px solid
+    ${({ $hasError, theme }) =>
+      $hasError ? theme.colors.alert : theme.colors.gray700};
+  border-radius: 0.8rem;
+  outline: none;
+
+  background-color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colors.white};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray300};
+    ${({ theme }) => theme.fonts.body_ligth_16};
+  }
+`;
+
+export default IntroInfo;

--- a/src/components/Profile/LanguageInfo.tsx
+++ b/src/components/Profile/LanguageInfo.tsx
@@ -1,13 +1,20 @@
 import styled from 'styled-components';
+import { LanguageInfoProps } from '../../types/Profile/ProfileType';
 import SelectBox from '../Register/SelectBox';
 
-const LanguageInfo = ({ selectedTag, handleChangeTag }) => {
+const LanguageInfo = ({ selectedTag, handleChangeTag }: LanguageInfoProps) => {
   return (
     <LanguageInfoContainer>
       <TitleContainer>
         <Title>주 언어</Title>
       </TitleContainer>
-      <SelectBox selectedTag={selectedTag} handleChangeTag={handleChangeTag} />
+      <SelectContainer>
+        <SelectBox
+          selectedTag={selectedTag}
+          handleChangeTag={handleChangeTag}
+        />
+      </SelectContainer>
+      <BorderBottom />
     </LanguageInfoContainer>
   );
 };
@@ -15,22 +22,35 @@ const LanguageInfo = ({ selectedTag, handleChangeTag }) => {
 const LanguageInfoContainer = styled.section`
   display: flex;
   align-items: center;
+  position: relative;
 
   padding-bottom: 1.4rem;
 
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
-const TitleContainer = styled.p`
+const TitleContainer = styled.div`
   display: flex;
 `;
 
-const Title = styled.p`
-  margin-right: 4.8rem;
+const Title = styled.h2`
+  margin: 1.4rem 7.6rem 1.4rem 0;
 
   color: ${({ theme }) => theme.colors.white};
 
   ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const SelectContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  padding-bottom: 1.4rem;
+`;
+
+const BorderBottom = styled.span`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
 export default LanguageInfo;

--- a/src/components/Profile/LanguageInfo.tsx
+++ b/src/components/Profile/LanguageInfo.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import SelectBox from '../Register/SelectBox';
+
+const LanguageInfo = ({ selectedTag, handleChangeTag }) => {
+  return (
+    <LanguageInfoContainer>
+      <TitleContainer>
+        <Title>주 언어</Title>
+      </TitleContainer>
+      <SelectBox selectedTag={selectedTag} handleChangeTag={handleChangeTag} />
+    </LanguageInfoContainer>
+  );
+};
+
+const LanguageInfoContainer = styled.section`
+  display: flex;
+  align-items: center;
+
+  padding-bottom: 1.4rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const TitleContainer = styled.p`
+  display: flex;
+`;
+
+const Title = styled.p`
+  margin-right: 4.8rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+export default LanguageInfo;

--- a/src/components/Profile/NameInfo.tsx
+++ b/src/components/Profile/NameInfo.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { NameInfoProps } from '../../types/Profile/ProfileType';
 
-const NameInfo = ({ user }) => {
+const NameInfo = ({ user }: NameInfoProps) => {
   return (
     <NameInfoContainer>
       <NameTitle>이름</NameTitle>
@@ -9,7 +10,7 @@ const NameInfo = ({ user }) => {
   );
 };
 
-const NameInfoContainer = styled.article`
+const NameInfoContainer = styled.section`
   display: flex;
   align-items: center;
 
@@ -19,12 +20,12 @@ const NameInfoContainer = styled.article`
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
-const NameTitle = styled.article`
+const NameTitle = styled.h2`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.title_bold_16};
 `;
 
-const Name = styled.article`
+const Name = styled.p`
   margin-left: 10.6rem;
 
   color: ${({ theme }) => theme.colors.gray100};

--- a/src/components/Profile/NameInfo.tsx
+++ b/src/components/Profile/NameInfo.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+const NameInfo = ({ user }) => {
+  return (
+    <NameInfoContainer>
+      <NameTitle>이름</NameTitle>
+      <Name>{user}</Name>
+    </NameInfoContainer>
+  );
+};
+
+const NameInfoContainer = styled.article`
+  display: flex;
+  align-items: center;
+
+  padding: 0 24.3rem 2.6rem 0;
+  margin-bottom: 3.2rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const NameTitle = styled.article`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const Name = styled.article`
+  margin-left: 10.6rem;
+
+  color: ${({ theme }) => theme.colors.gray100};
+
+  ${({ theme }) => theme.fonts.body_medium_16};
+`;
+
+export default NameInfo;

--- a/src/components/Profile/NicknameInfo.tsx
+++ b/src/components/Profile/NicknameInfo.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { NickNameInfoProps } from '../../types/Profile/ProfileType';
 import CommonInput from './../../common/CommonInput';
 
 const NicknameInfo = ({
@@ -6,7 +7,7 @@ const NicknameInfo = ({
 
   handleChangeInputs,
   handleNicknameCheck,
-}) => {
+}: NickNameInfoProps) => {
   return (
     <NicknameInfoContainer>
       <NicknameTitle>닉네임</NicknameTitle>
@@ -29,12 +30,13 @@ const NicknameInfoContainer = styled.section`
   align-items: center;
 
   padding-bottom: 1.4rem;
+  margin-bottom: 3.2rem;
 
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
 `;
 
-const NicknameTitle = styled.p`
-  margin-right: 4.8rem;
+const NicknameTitle = styled.h2`
+  margin-right: 8rem;
 
   color: ${({ theme }) => theme.colors.white};
 

--- a/src/components/Profile/NicknameInfo.tsx
+++ b/src/components/Profile/NicknameInfo.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import CommonInput from './../../common/CommonInput';
+
+const NicknameInfo = ({
+  nickname,
+
+  handleChangeInputs,
+  handleNicknameCheck,
+}) => {
+  return (
+    <NicknameInfoContainer>
+      <NicknameTitle>닉네임</NicknameTitle>
+      <InputWrapper>
+        <CommonInput
+          category="nickname"
+          value={nickname}
+          handleChangeInputs={handleChangeInputs}
+        />
+        <Button type="button" onClick={handleNicknameCheck}>
+          검색
+        </Button>
+      </InputWrapper>
+    </NicknameInfoContainer>
+  );
+};
+
+const NicknameInfoContainer = styled.section`
+  display: flex;
+  align-items: center;
+
+  padding-bottom: 1.4rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray600};
+`;
+
+const NicknameTitle = styled.p`
+  margin-right: 4.8rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Button = styled.button`
+  padding: 1.5rem 1.8rem 1.4rem;
+  margin-left: 1rem;
+
+  border: none;
+  border-radius: 0.6rem;
+  background-color: ${({ theme }) => theme.colors.codrive_green};
+  color: ${({ theme }) => theme.colors.gray900};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+export default NicknameInfo;

--- a/src/constants/CommonBtn/BtnContent.tsx
+++ b/src/constants/CommonBtn/BtnContent.tsx
@@ -20,4 +20,5 @@ export const CONTENTS = [
   { category: 'account_create', text: '가입하기' },
   { category: 'link_copy', text: '링크 복사하기', icon: <IcBtnCopy /> },
   { category: 'group_join', text: '참여하기' },
+  { category: 'Profile_save', text: '저장하기' },
 ];

--- a/src/page/ProfilePage.tsx
+++ b/src/page/ProfilePage.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import { useNavigate } from 'react-router-dom';
+import CommonButton from '../common/CommonButton';
+import GithubInfo from '../components/Profile/GIthubInfo';
+import IntroInfo from '../components/Profile/IntroInfo';
+import LanguageInfo from '../components/Profile/LanguageInfo';
+import NameInfo from '../components/Profile/NameInfo';
+import { handleInput } from '../utils/handleInput';
+import NicknameInfo from './../components/Profile/NicknameInfo';
+
+const ProfilePage = () => {
+  const [inputs, setInputs] = useState({
+    nickname: '',
+    github: '',
+    intro: '',
+  });
+
+  const [selectedLanguage, setSelectedLanguage] = useState('');
+  const navigate = useNavigate();
+
+  const { nickname, github, intro } = inputs;
+
+  // 입력 값 변경 처리 함수
+  const handleChangeInputs = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setInputs((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  // 언어 태그 변경 처리 함수
+  const handleChangeTag = (value: string) => {
+    setSelectedLanguage(value);
+  };
+
+  // 소개글 변경 처리 함수
+  const handleChangeIntro = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+    handleInput(e, 'intro');
+    setInputs((prev) => ({ ...prev, intro: value }));
+  };
+
+  // 가입 버튼 클릭 처리 함수
+  const handleSaveBtnClick = () => {
+    if (!isActive) return;
+  };
+
+  // 닉네임 중복 체크 함수 (구현 필요)
+  const handleNicknameCheck = async () => {
+    // 닉네임 중복 체크 로직 추가
+  };
+
+  const isActive =
+    nickname.length > 0 &&
+    nickname.length <= 10 &&
+    intro.length > 0 &&
+    intro.length <= 30 &&
+    github.length > 0 &&
+    selectedLanguage.length > 0;
+
+  return (
+    <ProfileContainer onSubmit={handleSaveBtnClick}>
+      <NameInfo />
+      <GithubInfo github={github} handleChangeInputs={handleChangeInputs} />
+      <IntroInfo value={intro} onChange={handleChangeIntro} />
+      <NicknameInfo
+        nickname={nickname}
+        handleChangeInputs={handleChangeInputs}
+        handleNicknameCheck={handleNicknameCheck}
+      />
+      <LanguageInfo
+        selectedTag={selectedLanguage}
+        handleChangeTag={handleChangeTag}
+      />
+      <ProfileButton>
+        <CommonButton
+          isActive={isActive}
+          category="Profile_save"
+          onClick={() => handleSaveBtnClick()}
+        />
+        <CancelButton onClick={() => navigator(-1)}>취소하기</CancelButton>
+      </ProfileButton>
+    </ProfileContainer>
+  );
+};
+
+const ProfileContainer = styled.div``;
+
+const ProfileButton = styled.button``;
+
+const CancelButton = styled.button`
+  padding: 1rem 2rem;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+export default ProfilePage;

--- a/src/page/ProfilePage.tsx
+++ b/src/page/ProfilePage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import styled from 'styled-components';
-
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import CommonButton from '../common/CommonButton';
+import PageLayout from '../components/PageLayout/PageLayout';
 import GithubInfo from '../components/Profile/GIthubInfo';
 import IntroInfo from '../components/Profile/IntroInfo';
 import LanguageInfo from '../components/Profile/LanguageInfo';
@@ -16,6 +16,8 @@ const ProfilePage = () => {
     github: '',
     intro: '',
   });
+
+  const user = '김문주';
 
   const [selectedLanguage, setSelectedLanguage] = useState('');
   const navigate = useNavigate();
@@ -46,6 +48,7 @@ const ProfilePage = () => {
   // 가입 버튼 클릭 처리 함수
   const handleSaveBtnClick = () => {
     if (!isActive) return;
+    navigate('/register');
   };
 
   // 닉네임 중복 체크 함수 (구현 필요)
@@ -62,37 +65,104 @@ const ProfilePage = () => {
     selectedLanguage.length > 0;
 
   return (
-    <ProfileContainer onSubmit={handleSaveBtnClick}>
-      <NameInfo />
-      <GithubInfo github={github} handleChangeInputs={handleChangeInputs} />
-      <IntroInfo value={intro} onChange={handleChangeIntro} />
-      <NicknameInfo
-        nickname={nickname}
-        handleChangeInputs={handleChangeInputs}
-        handleNicknameCheck={handleNicknameCheck}
-      />
-      <LanguageInfo
-        selectedTag={selectedLanguage}
-        handleChangeTag={handleChangeTag}
-      />
-      <ProfileButton>
-        <CommonButton
-          isActive={isActive}
-          category="Profile_save"
-          onClick={() => handleSaveBtnClick()}
-        />
-        <CancelButton onClick={() => navigator(-1)}>취소하기</CancelButton>
-      </ProfileButton>
-    </ProfileContainer>
+    <PageLayout category="홈">
+      <ModalBackground>
+        <ProfileContainer onSubmit={handleSaveBtnClick}>
+          <BasicInfoContainer>
+            <BasicTitle>기본정보</BasicTitle>
+            <NameInfo user={user} />
+            <GithubInfo
+              github={github}
+              handleChangeInputs={handleChangeInputs}
+            />
+          </BasicInfoContainer>
+          <CodriveContainer>
+            <CodriveTitle>코드라이브 정보</CodriveTitle>
+            <IntroInfo value={intro} onChange={handleChangeIntro} />
+            <NicknameInfo
+              nickname={nickname}
+              handleChangeInputs={handleChangeInputs}
+              handleNicknameCheck={handleNicknameCheck}
+            />
+            <LanguageInfo
+              selectedTag={selectedLanguage}
+              handleChangeTag={handleChangeTag}
+            />
+          </CodriveContainer>
+          <ProfileButton>
+            <CancelButton onClick={() => navigate(-1)}>취소하기</CancelButton>
+            <CommonButton
+              isActive={isActive}
+              category="Profile_save"
+              onClick={handleSaveBtnClick}
+            />
+          </ProfileButton>
+        </ProfileContainer>
+      </ModalBackground>
+    </PageLayout>
   );
 };
 
-const ProfileContainer = styled.div``;
+const ModalBackground = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
 
-const ProfileButton = styled.button``;
+  width: 100%;
+  height: 100%;
+
+  background-color: rgb(0 0 0 / 50%);
+`;
+
+const ProfileContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+
+  height: 554px;
+  padding: 6.4rem 9.6rem;
+
+  border-radius: 1rem;
+  background-color: ${({ theme }) => theme.colors.gray900};
+  overflow-y: auto;
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const BasicInfoContainer = styled.div`
+  margin-bottom: 8rem;
+`;
+
+const CodriveContainer = styled.div`
+  margin-bottom: 5.6rem;
+`;
+
+const BasicTitle = styled.h1`
+  margin-bottom: 5.2rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const CodriveTitle = styled.h1`
+  margin-bottom: 4rem;
+
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const ProfileButton = styled.div`
+  display: flex;
+
+  margin: 0 auto;
+`;
 
 const CancelButton = styled.button`
   padding: 1rem 2rem;
+  margin-right: 1.6rem;
 
   border-radius: 0.8rem;
   background-color: ${({ theme }) => theme.colors.gray700};

--- a/src/types/Profile/ProfileType.tsx
+++ b/src/types/Profile/ProfileType.tsx
@@ -1,0 +1,26 @@
+export interface GithubInfoProps {
+  github: string;
+  handleChangeInputs: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface IntroInfoProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  maxLength?: number;
+}
+
+export interface LanguageInfoProps {
+  selectedTag: string;
+  handleChangeTag: (value: string) => void;
+}
+
+export interface NickNameInfoProps {
+  nickname: string;
+
+  handleChangeInputs: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleNicknameCheck: () => void;
+}
+
+export interface NameInfoProps {
+  user: string;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #115 

## ✅ 작업 내용

- [x] 각 기능들 컴포넌트 화 시킴
- [x] 모달 높이 제한(내부 스크롤)

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/51fb2137-4361-4cfc-997a-0c76724e333f


## 📌 이슈 사항
프로필에 들어가는 기능들을 컴포넌트 화 시켜서 분리해 줬습니다. 
지금 구현한 내 프로필 뷰는 페이지로 들어가는 것이 아니라 마이페이지 뷰 모달로 들어가는 거라서 마이페이지 뷰가 완성되면 모달로 연결해 줄 예정입니다!
## 1️⃣ 취소하기 버튼
- 취소하기 버튼을 눌렀을 때 입력 값들이 그대로 있는 상황에서 단순히 취소가 되는 상황이라 `navigate(-1)` 로 구현했는데 이 방법이 맞는지 잘 모르겠습니다.
```
<CancelButton onClick={() => navigate(-1)}>취소하기</CancelButton>
```

## 2️⃣ 저장하기 버튼
- commonInput 에 저장하기 버튼을 추가해서 구현했습니다!
```
export const CONTENTS = [
  {
   ...
  },
  { category: 'account_create', text: '가입하기' },
  { category: 'link_copy', text: '링크 복사하기', icon: <IcBtnCopy /> },
  { category: 'group_join', text: '참여하기' },
  { category: 'Profile_save', text: '저장하기' }, -> 추가
];
```
## ✍ 궁금한 것
