### PR TITLE
[ Follower ] 팔로워 현황 상단 뷰 구현

### DIFF
--- a/src/assets/icon/ic_nothing.svg
+++ b/src/assets/icon/ic_nothing.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="50" viewBox="0 0 16 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8V50H0V8Z" fill="#292A2F"/>
+</svg>

--- a/src/assets/icon/ic_workbook_black.svg
+++ b/src/assets/icon/ic_workbook_black.svg
@@ -1,0 +1,6 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5697 12.2139H6.4873" stroke="#0B0C0F" stroke-width="1.125" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M9.02349 9.378H6.48633" stroke="#0B0C0F" stroke-width="1.125" stroke-linecap="square" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.9262 2.0625L3.24414 2.0625V15.9375H14.7561V6.05119L10.9262 2.0625Z" stroke="#0B0C0F" stroke-width="1.125" stroke-linecap="square"/>
+<path d="M10.5693 2.47852V6.48758H14.3996" stroke="#0B0C0F" stroke-width="1.125" stroke-linecap="square"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -40,6 +40,7 @@ import IcLoginIcon from './icon/ic_login_Icon.svg?react';
 import IcLogo from './icon/ic_logo.svg?react';
 import IcMemoGray from './icon/ic_memo_gray.svg?react';
 import IcMemoWhite from './icon/ic_memo_white.svg?react';
+import IcNothing from './icon/ic_nothing.svg?react';
 import IcSecretBigWhite from './icon/ic_secret_big_white.svg?react';
 import IcSecretGray from './icon/ic_secret_gray.svg?react';
 import IcSecretWhite from './icon/ic_secret_white.svg?react';
@@ -52,6 +53,7 @@ import IcUnfollowingWhite from './icon/ic_unfollowing_white.svg?react';
 import IcUnlockGray from './icon/ic_unlock_gray.svg?react';
 import IcUnlockWhite from './icon/ic_unlock_white.svg?react';
 import IcWorkbook from './icon/ic_workbook.svg?react';
+import IcWorkbookBlack from './icon/ic_workbook_black.svg?react';
 import Thumbnail from './icon/thumbnail.svg?react';
 
 import BtnHeart from './btn/btn_heart.svg?react';
@@ -111,6 +113,7 @@ export {
   IcLogo,
   IcMemoGray,
   IcMemoWhite,
+  IcNothing,
   IcSecretBigWhite,
   IcSecretGray,
   IcSecretWhite,
@@ -123,6 +126,7 @@ export {
   IcUnlockGray,
   IcUnlockWhite,
   IcWorkbook,
+  IcWorkbookBlack,
   TestWeekboardStatus,
   Thumbnail,
 };

--- a/src/components/Follower/Current/CustomTooltip.tsx
+++ b/src/components/Follower/Current/CustomTooltip.tsx
@@ -1,0 +1,57 @@
+import { TooltipProps } from 'recharts';
+import styled from 'styled-components';
+
+const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+  if (payload && payload.length && active) {
+    const { name, problemNum } = payload[0].payload;
+
+    return (
+      <ToolTipContainer>
+        <Name>{name}</Name>
+        <ProblemNum>{`${problemNum} 문제`}</ProblemNum>
+      </ToolTipContainer>
+    );
+  }
+};
+
+export default CustomTooltip;
+
+const ToolTipContainer = styled.div`
+  display: flex;
+  gap: 1.3rem;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  transform: translate(-7rem, -8.5rem);
+`;
+
+const Name = styled.p`
+  position: relative;
+
+  padding: 1rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_semiBold_14};
+
+  &::after {
+    position: absolute;
+    top: 3.7rem;
+    left: calc(100% / 2.2);
+
+    width: 0;
+
+    border-top: 1rem solid ${({ theme }) => theme.colors.gray500};
+    border-right: 1rem solid transparent;
+    border-left: 1rem solid transparent;
+
+    content: '';
+  }
+`;
+
+const ProblemNum = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.detail_regular_12};
+`;

--- a/src/components/Follower/Current/EmptyFollower.tsx
+++ b/src/components/Follower/Current/EmptyFollower.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import { IcNothing } from '../../../assets';
+
+const EmptyFollower = () => {
+  const nickname = sessionStorage.getItem('nickname');
+  const graphArr = Array.from({ length: 15 }, (_, idx) => idx);
+
+  return (
+    <EmptyFollowerContainer>
+      <TextContainer>
+        <Text>{nickname} 님은 팔로워가 아직 없어요</Text>
+        <Text>팔로워를 추가하여 주간 문제 개수를 비교해보세요</Text>
+      </TextContainer>
+
+      <SubText>
+        그룹 {'>'} 마음에 드는 그룹에 가입하여 팔로워를 추가해보세요
+      </SubText>
+
+      <GraphContainer>
+        {graphArr.map((graph) => {
+          return <IcNothing key={graph} />;
+        })}
+      </GraphContainer>
+    </EmptyFollowerContainer>
+  );
+};
+
+export default EmptyFollower;
+
+const EmptyFollowerContainer = styled.article`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  padding: 5.2rem 3.6rem 1.4rem 3.5rem;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  margin-bottom: 2.4rem;
+`;
+
+const Text = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const SubText = styled.p`
+  margin-bottom: 3rem;
+
+  color: ${({ theme }) => theme.colors.gray300};
+  ${({ theme }) => theme.fonts.detail_regular_12};
+`;
+
+const GraphContainer = styled.div`
+  display: flex;
+  gap: 1.8rem;
+  justify-content: center;
+
+  padding: 0 2.4rem;
+`;

--- a/src/components/Follower/Current/EmptySolver.tsx
+++ b/src/components/Follower/Current/EmptySolver.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { IcWorkbookBlack } from '../../../assets';
+
+const EmptySolver = () => {
+  return (
+    <EmptySolverContainer>
+      <TextContainer>
+        <Text>오늘 문제를 푼 팔로워가 아직 없어요</Text>
+        <Text>가장 먼저 문제를 풀어보세요!</Text>
+      </TextContainer>
+
+      <SolveBtn>
+        <IcWorkbookBlack />
+        <BtnText>문제풀이 인증하러 가기</BtnText>
+      </SolveBtn>
+    </EmptySolverContainer>
+  );
+};
+
+export default EmptySolver;
+
+const EmptySolverContainer = styled.div`
+  display: flex;
+  gap: 9.2rem;
+  align-items: baseline;
+  flex-direction: column;
+
+  margin: 2.8rem 0 2.4rem 2.4rem;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const Text = styled.p`
+  color: ${({ theme }) => theme.colors.gray200};
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const SolveBtn = styled.button`
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+
+  padding: 0.9rem 1.4rem;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme }) => theme.colors.codrive_green};
+`;
+
+const BtnText = styled.p`
+  ${({ theme }) => theme.fonts.title_bold_16};
+`;

--- a/src/components/Follower/Current/EmptySolver.tsx
+++ b/src/components/Follower/Current/EmptySolver.tsx
@@ -1,7 +1,14 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcWorkbookBlack } from '../../../assets';
 
 const EmptySolver = () => {
+  const navigate = useNavigate();
+
+  const handleClickSolveBtn = () => {
+    navigate('/solve');
+  };
+
   return (
     <EmptySolverContainer>
       <TextContainer>
@@ -9,7 +16,7 @@ const EmptySolver = () => {
         <Text>가장 먼저 문제를 풀어보세요!</Text>
       </TextContainer>
 
-      <SolveBtn>
+      <SolveBtn type="button" onClick={handleClickSolveBtn}>
         <IcWorkbookBlack />
         <BtnText>문제풀이 인증하러 가기</BtnText>
       </SolveBtn>

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -1,4 +1,4 @@
-import { Bar, BarChart, ResponsiveContainer } from 'recharts';
+import { Bar, BarChart, Cell, ResponsiveContainer } from 'recharts';
 
 interface FollowerCurrentGraphProps {
   users: Array<{
@@ -11,18 +11,47 @@ interface FollowerCurrentGraphProps {
 const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
   const data = users.map((user) => {
     const { nickname, problemNum } = user;
+    const height = problemNum * 10 + 10;
 
     return {
       name: nickname,
       problemNum: problemNum,
+      height: height,
     };
   });
 
   const filledData = Array(15)
     .fill(0)
     .map((_, index) => {
-      return data[index] || { name: '', problemNum: 0 };
+      return data[index] || { name: '', problemNum: 0, height: 50 };
     });
+
+  const getColor = (problemNum: number) => {
+    switch (problemNum) {
+      case 0:
+        return '#292A2F';
+      case 1:
+      case 2:
+      case 3:
+        return '#DCFFE4';
+      case 4:
+      case 5:
+      case 6:
+        return '#B7FFC7';
+      case 7:
+      case 8:
+      case 9:
+        return '#7DFF99';
+      case 10:
+      case 11:
+      case 12:
+        return '#59FF7E';
+      case 13:
+        return '#08FF3F';
+      default:
+        return '#08FF3F';
+    }
+  };
 
   return (
     <ResponsiveContainer
@@ -36,12 +65,11 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
         barCategoryGap={30}
         barGap={18}
       >
-        <Bar
-          dataKey="problemNum"
-          radius={[30, 30, 0, 0]}
-          fill="#59FF7E"
-          isAnimationActive={false}
-        />
+        <Bar dataKey="height" radius={[30, 30, 0, 0]} isAnimationActive={false}>
+          {filledData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={getColor(entry.problemNum)} />
+          ))}
+        </Bar>
       </BarChart>
     </ResponsiveContainer>
   );

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -1,0 +1,39 @@
+import { Bar, BarChart, ResponsiveContainer } from 'recharts';
+
+interface FollowerCurrentGraphProps {
+  users: Array<{
+    userId: number;
+    nickname: string;
+    problemNum: number;
+  }>;
+}
+
+const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
+  const data = users.map((user) => {
+    const { nickname, problemNum } = user;
+
+    return {
+      name: nickname,
+      problemNum: problemNum,
+    };
+  });
+
+  return (
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      style={{ padding: '0 24px' }}
+    >
+      <BarChart data={data} barSize={18} barCategoryGap={30} barGap={18}>
+        <Bar
+          dataKey="problemNum"
+          radius={[30, 30, 0, 0]}
+          fill="#59FF7E"
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default FollowerCurrentGraph;

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -1,6 +1,7 @@
-import { Bar, BarChart, Cell, ResponsiveContainer } from 'recharts';
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import styled from 'styled-components';
 import { FollowerCurrentGraphProps } from '../../../types/Follower/Current/currentType';
+import CustomTooltip from './CustomTooltip';
 
 const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
   const data = users.map((user) => {
@@ -53,10 +54,15 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
     <GraphContainer>
       <ResponsiveContainer
         //   데이터의 길이가 15보다 클 경우, 그래프를 보여주는 컨테이너 너비를 늘림
-        width={data.length > 15 ? data.length * 40 : '100%'}
+        width={data.length > 15 ? data.length * 38 : '100%'}
         height="100%"
       >
         <BarChart data={barArr} barSize={18} barCategoryGap={30} barGap={18}>
+          <Tooltip
+            content={<CustomTooltip />}
+            cursor={{ fill: 'transparent' }}
+            allowEscapeViewBox={{ x: true, y: true }}
+          />
           <Bar
             dataKey="height"
             radius={[30, 30, 0, 0]}
@@ -77,8 +83,9 @@ export default FollowerCurrentGraph;
 const GraphContainer = styled.div`
   overflow: auto hidden;
 
-  min-width: 57rem;
-
   height: 100%;
+  padding-top: 7.6rem;
   margin: 0 2.4rem;
+
+  min-width: 57rem;
 `;

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -1,12 +1,5 @@
 import { Bar, BarChart, Cell, ResponsiveContainer } from 'recharts';
-
-interface FollowerCurrentGraphProps {
-  users: Array<{
-    userId: number;
-    nickname: string;
-    problemNum: number;
-  }>;
-}
+import { FollowerCurrentGraphProps } from '../../../types/Follower/Current/currentType';
 
 const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
   const data = users.map((user) => {

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -1,4 +1,5 @@
 import { Bar, BarChart, Cell, ResponsiveContainer } from 'recharts';
+import styled from 'styled-components';
 import { FollowerCurrentGraphProps } from '../../../types/Follower/Current/currentType';
 
 const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
@@ -49,20 +50,35 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
   };
 
   return (
-    <ResponsiveContainer
-      width="100%"
-      height="100%"
-      style={{ padding: '0 24px' }}
-    >
-      <BarChart data={barArr} barSize={18} barCategoryGap={30} barGap={18}>
-        <Bar dataKey="height" radius={[30, 30, 0, 0]} isAnimationActive={false}>
-          {barArr.map((entry, index) => (
-            <Cell key={`cell-${index}`} fill={getColor(entry.problemNum)} />
-          ))}
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+    <GraphContainer>
+      <ResponsiveContainer
+        //   데이터의 길이가 15보다 클 경우, 그래프를 보여주는 컨테이너 너비를 늘림
+        width={data.length > 15 ? data.length * 40 : '100%'}
+        height="100%"
+      >
+        <BarChart data={barArr} barSize={18} barCategoryGap={30} barGap={18}>
+          <Bar
+            dataKey="height"
+            radius={[30, 30, 0, 0]}
+            isAnimationActive={false}
+          >
+            {barArr.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={getColor(entry.problemNum)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </GraphContainer>
   );
 };
 
 export default FollowerCurrentGraph;
+
+const GraphContainer = styled.div`
+  overflow: auto hidden;
+
+  min-width: 57rem;
+
+  height: 100%;
+  margin: 0 2.4rem;
+`;

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -19,6 +19,8 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
       return data[index] || { name: '', problemNum: 0, height: 50 };
     });
 
+  const barArr = data.length >= 15 ? data : filledData;
+
   const getColor = (problemNum: number) => {
     switch (problemNum) {
       case 0:
@@ -52,14 +54,9 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
       height="100%"
       style={{ padding: '0 24px' }}
     >
-      <BarChart
-        data={data.length >= 15 ? data : filledData}
-        barSize={18}
-        barCategoryGap={30}
-        barGap={18}
-      >
+      <BarChart data={barArr} barSize={18} barCategoryGap={30} barGap={18}>
         <Bar dataKey="height" radius={[30, 30, 0, 0]} isAnimationActive={false}>
-          {filledData.map((entry, index) => (
+          {barArr.map((entry, index) => (
             <Cell key={`cell-${index}`} fill={getColor(entry.problemNum)} />
           ))}
         </Bar>

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -18,13 +18,24 @@ const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
     };
   });
 
+  const filledData = Array(15)
+    .fill(0)
+    .map((_, index) => {
+      return data[index] || { name: '', problemNum: 0 };
+    });
+
   return (
     <ResponsiveContainer
       width="100%"
       height="100%"
       style={{ padding: '0 24px' }}
     >
-      <BarChart data={data} barSize={18} barCategoryGap={30} barGap={18}>
+      <BarChart
+        data={data.length >= 15 ? data : filledData}
+        barSize={18}
+        barCategoryGap={30}
+        barGap={18}
+      >
         <Bar
           dataKey="problemNum"
           radius={[30, 30, 0, 0]}

--- a/src/components/Follower/Current/FollowerList.tsx
+++ b/src/components/Follower/Current/FollowerList.tsx
@@ -10,8 +10,8 @@ import {
 import { DUMMY } from '../../../constants/Follower/currentConst';
 import FollowerRecommendCard from '../Personal/FollowerRecommendCard';
 import AdditionalProblemsModal from './AdditionalProblemsModal';
-import CurrentGraph from './CurrentGraph';
 import FollowerFilter from './FollowerFilter';
+import WeeklyCurrentGraph from './WeeklyCurrentGraph';
 
 const FollowerList = () => {
   const { followers } = DUMMY;
@@ -85,7 +85,7 @@ const FollowerList = () => {
                     <Nickname>{nickname}</Nickname>
                     <Language>{language}</Language>
                   </UserContainer>
-                  <CurrentGraph percentage={rate} />
+                  <WeeklyCurrentGraph percentage={rate} />
 
                   <Problem>{problem}</Problem>
                   {isExitAndClicked ? (

--- a/src/components/Follower/Current/FollowerList.tsx
+++ b/src/components/Follower/Current/FollowerList.tsx
@@ -207,6 +207,8 @@ const Contents = styled.div<{ $isClicked: boolean }>`
 
   background-color: ${({ $isClicked, theme }) =>
     $isClicked && theme.colors.gray800};
+
+  cursor: pointer;
 `;
 
 const ProfileImg = styled.img`
@@ -215,6 +217,8 @@ const ProfileImg = styled.img`
 
   border-radius: 0.8rem;
   object-fit: cover;
+
+  cursor: pointer;
 `;
 
 const UserContainer = styled.div`
@@ -227,6 +231,8 @@ const UserContainer = styled.div`
   width: 16rem;
   padding-left: 0.8rem;
   margin-right: 11.1rem;
+
+  cursor: pointer;
 `;
 
 const Nickname = styled.p`

--- a/src/components/Follower/Current/FollowerQuestions.tsx
+++ b/src/components/Follower/Current/FollowerQuestions.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import NumOfQuestions from './NumOfQuestions';
+import TodaysSolver from './TodaysSolver';
+
+const FollowerQuestions = () => {
+  return (
+    <FollowerQuestionsContainer>
+      <NumOfQuestions />
+      <TodaysSolver />
+    </FollowerQuestionsContainer>
+  );
+};
+
+export default FollowerQuestions;
+
+const FollowerQuestionsContainer = styled.section`
+  display: flex;
+  gap: 1.8rem;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  margin-top: 4rem;
+`;

--- a/src/components/Follower/Current/NumOfQuestions.tsx
+++ b/src/components/Follower/Current/NumOfQuestions.tsx
@@ -43,12 +43,15 @@ const Title = styled.p`
 `;
 
 const GraphContainer = styled.article`
-  width: 100%;
-  min-height: 23rem;
-  min-width: 61.1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
+  width: 100%;
+  height: 23rem;
   padding: 1rem 2.1rem 1.4rem 2rem;
 
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray800};
+  min-width: 61.1rem;
 `;

--- a/src/components/Follower/Current/NumOfQuestions.tsx
+++ b/src/components/Follower/Current/NumOfQuestions.tsx
@@ -33,6 +33,7 @@ const NumOfQuestionsContainer = styled.article`
   flex-direction: column;
   flex-grow: 2.1;
 
+  width: 61.1rem;
   margin-left: 0.2rem;
 `;
 

--- a/src/components/Follower/Current/NumOfQuestions.tsx
+++ b/src/components/Follower/Current/NumOfQuestions.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 import { IcInformation } from '../../../assets';
+import { TOTAL_FOLLOWERS_DUMMY } from '../../../constants/Follower/currentConst';
 import EmptyFollower from './EmptyFollower';
+import FollowerCurrentGraph from './FollowerCurrentGraph';
 
 const NumOfQuestions = () => {
+  const { users } = TOTAL_FOLLOWERS_DUMMY;
   return (
     <NumOfQuestionsContainer>
       <Header>
@@ -11,7 +14,11 @@ const NumOfQuestions = () => {
       </Header>
 
       <GraphContainer>
-        <EmptyFollower />
+        {users.length ? (
+          <FollowerCurrentGraph users={users} />
+        ) : (
+          <EmptyFollower />
+        )}
       </GraphContainer>
     </NumOfQuestionsContainer>
   );
@@ -45,11 +52,11 @@ const Title = styled.p`
 const GraphContainer = styled.article`
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: end;
 
   width: 100%;
   height: 23rem;
-  padding: 1rem 2.1rem 1.4rem 2rem;
+  padding: 7.6rem 2.1rem 1.4rem 2rem;
 
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray800};

--- a/src/components/Follower/Current/NumOfQuestions.tsx
+++ b/src/components/Follower/Current/NumOfQuestions.tsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+import { IcInformation } from '../../../assets';
+import EmptyFollower from './EmptyFollower';
+
+const NumOfQuestions = () => {
+  return (
+    <NumOfQuestionsContainer>
+      <Header>
+        <Title>문제 개수 그래프</Title>
+        <IcInformation />
+      </Header>
+
+      <GraphContainer>
+        <EmptyFollower />
+      </GraphContainer>
+    </NumOfQuestionsContainer>
+  );
+};
+
+export default NumOfQuestions;
+
+const NumOfQuestionsContainer = styled.article`
+  display: flex;
+  gap: 3.2rem;
+  justify-content: center;
+  flex-direction: column;
+  flex-grow: 2.1;
+
+  margin-left: 0.2rem;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 2.4rem;
+  align-items: center;
+
+  margin-left: 0.4rem;
+`;
+
+const Title = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const GraphContainer = styled.article`
+  width: 100%;
+  min-height: 23rem;
+  min-width: 61.1rem;
+
+  padding: 1rem 2.1rem 1.4rem 2rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.gray800};
+`;

--- a/src/components/Follower/Current/NumOfQuestions.tsx
+++ b/src/components/Follower/Current/NumOfQuestions.tsx
@@ -54,10 +54,11 @@ const GraphContainer = styled.article`
   display: flex;
   justify-content: center;
   align-items: end;
+  position: relative;
 
   width: 100%;
   height: 23rem;
-  padding: 7.6rem 2.1rem 1.4rem 2rem;
+  padding: 0 2.1rem 1.4rem 2rem;
 
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray800};

--- a/src/components/Follower/Current/Solver.tsx
+++ b/src/components/Follower/Current/Solver.tsx
@@ -1,14 +1,24 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { TODAYS_SOLVER_DUMMY } from '../../../constants/Follower/currentConst';
 import EmptySolver from './EmptySolver';
 
-const Solver = () => {
-  const { users } = TODAYS_SOLVER_DUMMY;
+interface SolverProps {
+  currentPage: number;
+  users: Array<{ userId: number; nickname: string; profileImg: string }>;
+}
+
+const Solver = ({ currentPage, users }: SolverProps) => {
+  const [slicedUsers, setSlicedUsers] = useState(users.slice(0, 3));
+
+  useEffect(() => {
+    setSlicedUsers(users.slice(currentPage * 3 - 3, currentPage * 3));
+  }, [currentPage]);
+
   return (
     <>
       {users.length ? (
         <SolverContainer>
-          {users.map((solver) => {
+          {slicedUsers.map((solver) => {
             const { userId, profileImg, nickname } = solver;
             return (
               <SolverInfo key={userId}>

--- a/src/components/Follower/Current/Solver.tsx
+++ b/src/components/Follower/Current/Solver.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+import { TODAYS_SOLVER_DUMMY } from '../../../constants/Follower/currentConst';
+import EmptySolver from './EmptySolver';
+
+const Solver = () => {
+  const { users } = TODAYS_SOLVER_DUMMY;
+  return (
+    <>
+      {users.length ? (
+        <SolverContainer>
+          {users.map((solver) => {
+            const { userId, profileImg, nickname } = solver;
+            return (
+              <SolverInfo key={userId}>
+                <ProfileImg src={profileImg} />
+                <Nickname>{nickname}</Nickname>
+              </SolverInfo>
+            );
+          })}
+        </SolverContainer>
+      ) : (
+        <EmptySolver />
+      )}
+    </>
+  );
+};
+
+export default Solver;
+
+const SolverContainer = styled.article`
+  display: flex;
+  gap: 2.4rem;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  padding: 4rem 5.3rem 4rem 4rem;
+`;
+
+const SolverInfo = styled.div`
+  display: flex;
+  gap: 1.4rem;
+  align-items: center;
+
+  width: 100%;
+  padding: 0.5rem 0 0.5rem 0.5rem;
+`;
+
+const ProfileImg = styled.img`
+  width: 2.4rem;
+  height: 2.4rem;
+
+  border-radius: 5rem;
+
+  object-fit: cover;
+`;
+
+const Nickname = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_semiBold_18};
+`;

--- a/src/components/Follower/Current/TodaysSolver.tsx
+++ b/src/components/Follower/Current/TodaysSolver.tsx
@@ -1,17 +1,40 @@
+import { useState } from 'react';
 import styled from 'styled-components';
-import { IcInformation } from '../../../assets';
+import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../../assets';
+import { TODAYS_SOLVER_DUMMY } from '../../../constants/Follower/currentConst';
 import Solver from './Solver';
 
 const TodaysSolver = () => {
+  const { totalPages, users } = TODAYS_SOLVER_DUMMY;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const handleClickArrowLeft = () => {
+    if (currentPage > 1) {
+      setCurrentPage((prev) => (prev -= 1));
+    }
+  };
+
+  const handleClickArrowRight = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage((prev) => (prev += 1));
+    }
+  };
+
   return (
     <TodaysSolverContainer>
       <Header>
         <Title>오늘 문제 푼 팔로워</Title>
-        <IcInformation />
+
+        {users.length && (
+          <ArrowContainer>
+            <IcArrowLeftSmallGray onClick={handleClickArrowLeft} />
+            <IcArrowRightSmallGray onClick={handleClickArrowRight} />
+          </ArrowContainer>
+        )}
       </Header>
 
       <SolverContainer>
-        <Solver />
+        <Solver currentPage={currentPage} users={users} />
       </SolverContainer>
     </TodaysSolverContainer>
   );
@@ -30,14 +53,23 @@ const TodaysSolverContainer = styled.article`
 const Header = styled.header`
   display: flex;
   gap: 2.4rem;
+  justify-content: space-between;
   align-items: center;
 
+  margin-right: 1rem;
   margin-left: 0.6rem;
 `;
 
 const Title = styled.p`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const ArrowContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
 `;
 
 const SolverContainer = styled.article`

--- a/src/components/Follower/Current/TodaysSolver.tsx
+++ b/src/components/Follower/Current/TodaysSolver.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import { IcInformation } from '../../../assets';
+import EmptySolver from './EmptySolver';
+
+const TodaysSolver = () => {
+  return (
+    <TodaysSolverContainer>
+      <Header>
+        <Title>오늘 문제 푼 팔로워</Title>
+        <IcInformation />
+      </Header>
+
+      <SolverContainer>
+        <EmptySolver />
+      </SolverContainer>
+    </TodaysSolverContainer>
+  );
+};
+
+export default TodaysSolver;
+
+const TodaysSolverContainer = styled.article`
+  display: flex;
+  gap: 3.2rem;
+  justify-content: center;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 2.4rem;
+  align-items: center;
+
+  margin-left: 0.6rem;
+`;
+
+const Title = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.title_bold_20};
+`;
+
+const SolverContainer = styled.article`
+  width: 100%;
+  min-width: 29.5rem;
+  min-height: 23rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.gray800};
+`;

--- a/src/components/Follower/Current/TodaysSolver.tsx
+++ b/src/components/Follower/Current/TodaysSolver.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { IcInformation } from '../../../assets';
-import EmptySolver from './EmptySolver';
+import Solver from './Solver';
 
 const TodaysSolver = () => {
   return (
@@ -11,7 +11,7 @@ const TodaysSolver = () => {
       </Header>
 
       <SolverContainer>
-        <EmptySolver />
+        <Solver />
       </SolverContainer>
     </TodaysSolverContainer>
   );
@@ -42,8 +42,8 @@ const Title = styled.p`
 
 const SolverContainer = styled.article`
   width: 100%;
+  height: 23rem;
   min-width: 29.5rem;
-  min-height: 23rem;
 
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.gray800};

--- a/src/components/Follower/Current/WeeklyCurrentGraph.tsx
+++ b/src/components/Follower/Current/WeeklyCurrentGraph.tsx
@@ -1,9 +1,9 @@
 import { Cell, Pie, PieChart } from 'recharts';
 import styled from 'styled-components';
 import { GRAPH_COLORS } from '../../../constants/Follower/currentConst';
-import { CurrentGraphProps } from '../../../types/Follower/Current/currentType';
+import { WeeklyCurrentGraphProps } from '../../../types/Follower/Current/currentType';
 
-const CurrentGraph = ({ percentage }: CurrentGraphProps) => {
+const WeeklyCurrentGraph = ({ percentage }: WeeklyCurrentGraphProps) => {
   const process = [{ name: 'Progress', value: percentage }];
 
   const remaining = [{ name: 'Remaining', value: 100 - percentage }];
@@ -47,7 +47,7 @@ const CurrentGraph = ({ percentage }: CurrentGraphProps) => {
   );
 };
 
-export default CurrentGraph;
+export default WeeklyCurrentGraph;
 
 const GraphContainer = styled.div`
   flex-grow: 1;

--- a/src/components/Follower/Current/WeeklyCurrentGraph.tsx
+++ b/src/components/Follower/Current/WeeklyCurrentGraph.tsx
@@ -64,7 +64,7 @@ const Rate = styled.p`
   position: absolute;
   top: 0;
 
-  width: 100%;
+  width: 5.5rem;
   padding: 1.8rem 1rem 1.8rem 1.1rem;
 
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/Follower/Current/WeeklyCurrentGraph.tsx
+++ b/src/components/Follower/Current/WeeklyCurrentGraph.tsx
@@ -5,7 +5,6 @@ import { WeeklyCurrentGraphProps } from '../../../types/Follower/Current/current
 
 const WeeklyCurrentGraph = ({ percentage }: WeeklyCurrentGraphProps) => {
   const process = [{ name: 'Progress', value: percentage }];
-
   const remaining = [{ name: 'Remaining', value: 100 - percentage }];
 
   return (
@@ -59,14 +58,15 @@ const GraphContainer = styled.div`
 `;
 
 const Rate = styled.p`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
   top: 0;
 
-  width: 5.5rem;
+  width: 100%;
   padding: 1.8rem 1rem 1.8rem 1.1rem;
 
   color: ${({ theme }) => theme.colors.white};
-
   ${({ theme }) => theme.fonts.title_bold_14};
-  text-align: center;
 `;

--- a/src/constants/Follower/currentConst.ts
+++ b/src/constants/Follower/currentConst.ts
@@ -200,6 +200,7 @@ export const TOTAL_FOLLOWERS_DUMMY = {
 };
 
 export const TODAYS_SOLVER_DUMMY = {
+  totalPages: 3,
   users: [
     {
       userId: 1,

--- a/src/constants/Follower/currentConst.ts
+++ b/src/constants/Follower/currentConst.ts
@@ -159,5 +159,88 @@ export const CLICKED_DUMMY = {
   ],
 };
 
-const TOTAL_LISTS = 6;
-export const TOTAL_PAGES = Math.ceil(TOTAL_LISTS / 4);
+export const TOTAL_FOLLOWERS_DUMMY = {
+  users: [
+    {
+      userId: 1,
+      nickname: '닉네임은총열글자입니',
+      problemNum: 3,
+    },
+    {
+      userId: 2,
+      nickname: '나는야루밍이',
+      problemNum: 7,
+    },
+    {
+      userId: 3,
+      nickname: '코딩하는갱얼쥐',
+      problemNum: 3,
+    },
+    {
+      userId: 4,
+      nickname: '우엥엥4번인간',
+      problemNum: 5,
+    },
+    {
+      userId: 5,
+      nickname: '5번사용자아아아',
+      problemNum: 15,
+    },
+    {
+      userId: 6,
+      nickname: '6번사용자입니다람쥐',
+      problemNum: 7,
+    },
+    {
+      userId: 7,
+      nickname: '7번사용자입니다람쥐',
+      problemNum: 3,
+    },
+  ],
+};
+
+export const TODAYS_SOLVER_DUMMY = {
+  users: [
+    {
+      userId: 1,
+      nickname: '닉네임은총열글자입니',
+      profileImg: 'https://avatars.githubusercontent.com/u/80264647?v=4',
+    },
+    {
+      userId: 2,
+      nickname: '나는야루밍이',
+      profileImg:
+        'https://i.pinimg.com/236x/b8/03/af/b803afd5c604e555159e683072e4ca31.jpg',
+    },
+    {
+      userId: 3,
+      nickname: '코딩하는갱얼쥐',
+      profileImg:
+        'https://i.pinimg.com/236x/b7/cd/1a/b7cd1acf6dc183795741c1c5ead481fd.jpg',
+    },
+    {
+      userId: 4,
+      nickname: '우엥엥4번인간',
+      profileImg:
+        'https://i.pinimg.com/236x/df/13/e6/df13e6bfcd025ef8bc865b14b530f300.jpg',
+    },
+    {
+      userId: 5,
+      nickname: '5번사용자아아아',
+      profileImg:
+        'https://i.pinimg.com/236x/a7/6a/47/a76a47686480dcfdd9a19043dbd99171.jpg',
+    },
+    {
+      userId: 6,
+      nickname: '6번사용자입니다람쥐',
+      profileImg:
+        'https://i.pinimg.com/564x/35/ea/46/35ea46d7ff554bdd4f47f52b7f535f5e.jpg',
+    },
+    {
+      userId: 7,
+      nickname: '7번사용자입니다람쥐',
+      profileImg:
+        'https://i.pinimg.com/564x/35/ea/46/35ea46d7ff554bdd4f47f52b7f535f5e.jpg',
+    },
+  ],
+};

--- a/src/page/FollowerCurrentPage.tsx
+++ b/src/page/FollowerCurrentPage.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import FollowerList from '../components/Follower/Current/FollowerList';
+import FollowerQuestions from '../components/Follower/Current/FollowerQuestions';
 import PageLayout from '../components/PageLayout/PageLayout';
 
 const FollowerCurrentPage = () => {
@@ -11,6 +12,8 @@ const FollowerCurrentPage = () => {
           <Date>7월 15일 - 21일</Date>
           <Text>주간보드</Text>
         </Header>
+
+        <FollowerQuestions />
 
         <FollowerList />
       </FollowerCurrentPageContainer>

--- a/src/types/Follower/Current/currentType.ts
+++ b/src/types/Follower/Current/currentType.ts
@@ -20,6 +20,6 @@ export interface ClickDailyBoardProps {
   date: string;
 }
 
-export interface CurrentGraphProps {
+export interface WeeklyCurrentGraphProps {
   percentage: number;
 }

--- a/src/types/Follower/Current/currentType.ts
+++ b/src/types/Follower/Current/currentType.ts
@@ -23,3 +23,11 @@ export interface ClickDailyBoardProps {
 export interface WeeklyCurrentGraphProps {
   percentage: number;
 }
+
+export interface FollowerCurrentGraphProps {
+  users: Array<{
+    userId: number;
+    nickname: string;
+    problemNum: number;
+  }>;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #141 

## ✅ 작업 내용

- [x] 문제 개수 그래프 컴포넌트
- [x] 오늘 문제 푼 팔로워 컴포넌트

## 📸 스크린샷 / GIF / Link

### 🚦 팔로워가 15명 이하인 경우

![스크린샷 2024-08-22 오후 7 05 19](https://github.com/user-attachments/assets/c51624af-2392-4c86-b9ab-61108b4a4e65)


<br />

### 🚦 팔로워가 16명 이상인 경우
- 원래는 그래프 호버로 툴팁이 뜨는데 모바일 뷰로 작게 띄워놓고 보느라 그래프 클릭해서 영상 찍었습니당

https://github.com/user-attachments/assets/1910834d-9d61-45b9-ad8d-13ea24cf4b39


## 📌 이슈 사항
### 0️⃣ 팔로워 수가 15명보다 적은 경우
- 팔로워 수가 15명 이하인 경우, 빈 막대 그래프를 세워야 해서 이 때는 유저 정보를 채운 뒤, 15번째 인덱스까지 `{ name: '', problemNum: 0, height: 50 }`로 채워진 배열을 만들어서 사용했습니다.

```typescript
  // 원래 팔로워 데이터
  const data = users.map((user) => {
    const { nickname, problemNum } = user;
    const height = problemNum * 10 + 10;

    return {
      name: nickname,
      problemNum: problemNum,
      height: height,
    };
  });
  
  // 가공한 팔로워 데이터
  const filledData = Array(15)
    .fill(0)
    .map((_, index) => {
      return data[index] || { name: '', problemNum: 0, height: 50 };
    });
    
  // 팔로워 수에 따라 그래프 구현에 사용할 배열 선택
  const barArr = data.length >= 15 ? data : filledData;
```

<br />

### 1️⃣ 푼 문제 수에 따라 그래프 색상 다르게 렌더링
- `getColor` 라는 함수를 만들어서 문제 수에 맞는 색상을 렌더링했습니다.
- 그런데 문제 수가 0인 경우에는 그래프 자체가 나타나지 않기 때문에, 그래프 높이를 나타내는 데이터(height)를 하나 만들어서 이 값을 그래프 키 값으로 사용했습니다. 
(피그마에 나온 것을 보면 `문제수 * 10 + 10`가 그래프의 높이가 되기 때문에 이 값을 height에 할당했어요 !)

<br />

### 2️⃣ 팔로워 문제풀이 정보를 알 수 있는 툴팁
- 이 부분에서 정말정말정말저정말 고민을 많이 했는데요 ,,
- 일단은 recharts에서 제공하는 Tooltip을 가공해서 사용했습니다. 
그런데 사이드 쪽 툴팁은 그래프 컨테이너 크기를 넘어가서 잘려버리더라구요 이걸 해결하려고 마진 대신 패딩 값으로 사이드 여백을 조절해봤는데, 패딩을 주니까 스크롤 너비가 패딩 값만큼 늘어나서 또 어색한 느낌이 들었어요 ..!!!!!! ㅜㅠㅜ 🤯🤯🤯 
결국 원하는 결과를 내지는 못했고 현재 작업한 것 중 최선의 코드로 올립니다 .. 차차 더 만져볼게요

<br />


### 3️⃣ 오늘 문제 푼 팔로워 렌더링
- 오늘 문제 푼 모든 팔로워 정보를 받아온 뒤, 페이지마다 3명 씩 잘라서 화면에 렌더링했습니다.

