### PR TITLE
[ Follower ] 팔로우/ 언팔로우 api 연결

### DIFF
--- a/src/components/Follower/Current/CustomTooltip.tsx
+++ b/src/components/Follower/Current/CustomTooltip.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 
 const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
   if (payload && payload.length && active) {
-    const { name, problemNum } = payload[0].payload;
+    const { name, count } = payload[0].payload;
 
     return (
       <>
-        {problemNum !== 0 && (
+        {name && (
           <ToolTipContainer>
             <Name>{name}</Name>
-            <ProblemNum>{`${problemNum} 문제`}</ProblemNum>
+            <ProblemNum>{`${count} 문제`}</ProblemNum>
           </ToolTipContainer>
         )}
       </>
@@ -27,7 +27,7 @@ const ToolTipContainer = styled.div`
   align-items: center;
   flex-direction: column;
 
-  transform: translate(-7rem, -8.5rem);
+  transform: translate(-4rem, -8.5rem);
 `;
 
 const Name = styled.p`
@@ -43,7 +43,7 @@ const Name = styled.p`
   &::after {
     position: absolute;
     top: 3.6rem;
-    left: calc(100% / 2.2);
+    left: calc(100% / 3);
 
     width: 0;
 

--- a/src/components/Follower/Current/FollowerCurrentGraph.tsx
+++ b/src/components/Follower/Current/FollowerCurrentGraph.tsx
@@ -6,7 +6,7 @@ import CustomTooltip from './CustomTooltip';
 const FollowerCurrentGraph = ({ users }: FollowerCurrentGraphProps) => {
   const data = users.map((user) => {
     const { nickname, count } = user;
-    const height = count * 10 + 10;
+    const height = count === 0 ? 50 : count * 10 + 10;
 
     return {
       name: nickname,

--- a/src/components/Follower/FollowerInfo.tsx
+++ b/src/components/Follower/FollowerInfo.tsx
@@ -153,11 +153,11 @@ const FollowingBtn = styled.button<{ $isFollowed: boolean }>`
   border-bottom-right-radius: 1.6rem;
 
   background-color: ${({ theme, $isFollowed }) =>
-    $isFollowed ? theme.color.gray700 : theme.colors.codrive_purple};
+    $isFollowed ? theme.colors.gray700 : theme.colors.codrive_purple};
 `;
 
 const Text = styled.p<{ $isFollowed: boolean }>`
   color: ${({ theme, $isFollowed }) =>
-    $isFollowed ? theme.color.gray100 : theme.colors.white};
+    $isFollowed ? theme.colors.gray100 : theme.colors.white};
   ${({ theme }) => theme.fonts.title_bold_16};
 `;

--- a/src/components/Follower/FollowerInfo.tsx
+++ b/src/components/Follower/FollowerInfo.tsx
@@ -1,12 +1,9 @@
-// import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import {
   IcFollowingGray,
   IcGithubSmall,
   IcUnfollowingWhite,
 } from '../../assets';
-import { deleteFollower } from '../../libs/apis/Follower/deleteFollower';
-import { postFollower } from '../../libs/apis/Follower/postFollower';
 import { FollowerInfoProps } from '../../types/Follower/Personal/personalType';
 import { handleClickLink } from '../../utils/handleClickLink';
 
@@ -21,19 +18,7 @@ const FollowerInfo = ({ info }: FollowerInfoProps) => {
     // successRate,
   } = info;
 
-  const handleClickFollowBtn = async () => {
-    try {
-      isFollowing ? await deleteFollower('문주') : await postFollower('문주');
-
-      // 추후 아래 코드로 변경할 예정
-      // isFollowed ? await deleteFollower(nickname) : await postFollower(nickname);
-    } catch (error) {
-      console.log(error);
-
-      // 추후 아래 코드로 변경할 예정
-      // navigate('/error');
-    }
-  };
+  const handleClickFollowBtn = () => {};
 
   return (
     <FollowerInfoContainer>

--- a/src/components/Follower/FollowerInfo.tsx
+++ b/src/components/Follower/FollowerInfo.tsx
@@ -4,6 +4,7 @@ import {
   IcGithubSmall,
   IcUnfollowingWhite,
 } from '../../assets';
+import useUpdateFollower from '../../libs/hooks/Follower/useUpdateFollower';
 import { FollowerInfoProps } from '../../types/Follower/Personal/personalType';
 import { handleClickLink } from '../../utils/handleClickLink';
 
@@ -18,7 +19,11 @@ const FollowerInfo = ({ info }: FollowerInfoProps) => {
     // successRate,
   } = info;
 
-  const handleClickFollowBtn = () => {};
+  const { mutation } = useUpdateFollower();
+
+  const handleClickFollowBtn = () => {
+    mutation({ isDelete: isFollowing, nickname: nickname });
+  };
 
   return (
     <FollowerInfoContainer>
@@ -161,3 +166,4 @@ const Text = styled.p<{ $isFollowed: boolean }>`
     $isFollowed ? theme.colors.gray100 : theme.colors.white};
   ${({ theme }) => theme.fonts.title_bold_16};
 `;
+

--- a/src/components/Follower/Personal/FollowerRecommendCard.tsx
+++ b/src/components/Follower/Personal/FollowerRecommendCard.tsx
@@ -6,12 +6,22 @@ import {
   IcUnfollowingWhite,
 } from '../../../assets';
 import useGetFollowerRecommend from '../../../libs/hooks/Follower/useGetFollowerRecommend';
+import useUpdateFollower from '../../../libs/hooks/Follower/useUpdateFollower';
+import { UpdateFollowerProps } from '../../../types/Follower/Personal/personalType';
 
 const FollowerRecommendCard = () => {
   const myNickname = sessionStorage.getItem('nickname');
 
   const { data, isLoading } = useGetFollowerRecommend();
+  const { mutation } = useUpdateFollower();
   const { users } = !isLoading && data.data;
+
+  const handleClickFollowerBtn = ({
+    nickname,
+    isDelete,
+  }: UpdateFollowerProps) => {
+    mutation({ nickname, isDelete });
+  };
 
   return (
     <RecommendCardContainer>
@@ -60,7 +70,16 @@ const FollowerRecommendCard = () => {
                     <Language>{`#${language}`}</Language>
                   </ProfileInfo>
 
-                  <FollowingBtn type="button" $isFollowed={isFollowing}>
+                  <FollowingBtn
+                    type="button"
+                    $isFollowed={isFollowing}
+                    onClick={() =>
+                      handleClickFollowerBtn({
+                        nickname,
+                        isDelete: isFollowing,
+                      })
+                    }
+                  >
                     {isFollowing ? <IcFollowingGray /> : <IcUnfollowingWhite />}
                     <FollowingText $isFollowed={isFollowing}>
                       {isFollowing ? `팔로잉` : `팔로우`}

--- a/src/libs/apis/Follower/deleteFollower.ts
+++ b/src/libs/apis/Follower/deleteFollower.ts
@@ -1,7 +1,0 @@
-import { api } from '../../api';
-
-export const deleteFollower = async (nickname: string) => {
-  const data = await api.delete(`/follow/${nickname}`);
-
-  return data;
-};

--- a/src/libs/apis/Follower/postFollower.ts
+++ b/src/libs/apis/Follower/postFollower.ts
@@ -1,7 +1,0 @@
-import { api } from '../../api';
-
-export const postFollower = async (nickname: string) => {
-  const data = await api.post(`/follow/${nickname}`);
-
-  return data;
-};

--- a/src/libs/apis/Follower/updateFollower.ts
+++ b/src/libs/apis/Follower/updateFollower.ts
@@ -1,0 +1,12 @@
+import { UpdateFollowerProps } from '../../../types/Follower/Personal/personalType';
+import { api } from '../../api';
+
+const updateFollower = async ({ isDelete, nickname }: UpdateFollowerProps) => {
+  const { data } = isDelete
+    ? await api.delete(`/follow/${nickname}`)
+    : await api.post(`/follow/${nickname}`);
+
+  return data;
+};
+
+export default updateFollower;

--- a/src/libs/hooks/Follower/useGetFollowerSummary.ts
+++ b/src/libs/hooks/Follower/useGetFollowerSummary.ts
@@ -8,7 +8,7 @@ const useGetFollowerSummary = ({
   groupId,
 }: GetFollowerSummaryProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-follower-summary', sortType, groupId],
+    queryKey: ['get-follower-summary', sortType, groupId, page],
     queryFn: async () => await getFollowerSummary({ sortType, groupId, page }),
   });
 

--- a/src/libs/hooks/Follower/useUpdateFollower.ts
+++ b/src/libs/hooks/Follower/useUpdateFollower.ts
@@ -9,13 +9,17 @@ const useUpdateFollower = () => {
     mutationFn: async ({ isDelete, nickname }: UpdateFollowerProps) =>
       await updateFollower({ nickname, isDelete }),
     onError: (err) => console.log(err.message),
-    onSuccess: () =>
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-follower-summary'] });
+      queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
+      queryClient.invalidateQueries({ queryKey: ['get-follower-recommend'] });
       queryClient.invalidateQueries({
         queryKey: ['get-follower-weekly-count'],
-      }),
+      });
+    },
   });
 
-  return { mutation: mutation.mutate, isLoading: mutation.isPending };
+  return { mutation: mutation.mutate };
 };
 
 export default useUpdateFollower;

--- a/src/libs/hooks/Follower/useUpdateFollower.ts
+++ b/src/libs/hooks/Follower/useUpdateFollower.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UpdateFollowerProps } from '../../../types/Follower/Personal/personalType';
+import updateFollower from '../../apis/Follower/updateFollower';
+
+const useUpdateFollower = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ isDelete, nickname }: UpdateFollowerProps) =>
+      await updateFollower({ nickname, isDelete }),
+    onError: (err) => console.log(err.message),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['get-follower-weekly-count'],
+      }),
+  });
+
+  return { mutation: mutation.mutate, isLoading: mutation.isPending };
+};
+
+export default useUpdateFollower;

--- a/src/types/Follower/Personal/personalType.ts
+++ b/src/types/Follower/Personal/personalType.ts
@@ -9,3 +9,8 @@ export interface FollowerInfoProps {
     successRate: number;
   };
 }
+
+export interface UpdateFollowerProps {
+  isDelete: boolean;
+  nickname: string;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #97 
## ✅ 작업 내용

- [x] 팔로우 api 연결
- [x] 언팔로우 api 연결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/fa6541ff-342e-4c00-a196-35ea1454739e


## 📌 이슈 사항
### 1️⃣ 팔로우/ 언팔로우 api 공통 함수로 구현
- 두 api가 post/ delete인 것만 빼면 모두 동일한 구조를 가져서 공통 함수로 구현했어요
- 팔로우/ 언팔로우가 진행될 때는 무조건 현재 팔로우 여부 데이터를 가지고 있기 때문에, 팔로우 여부 값을 props로 받아서 현재 팔로우 중이라면 delete 함수를 호출하고 언팔로우 중이라면 post 함수를 호출했습니다.
```typescript
const updateFollower = async ({ isDelete, nickname }: UpdateFollowerProps) => {
  const { data } = isDelete
    ? await api.delete(`/follow/${nickname}`)
    : await api.post(`/follow/${nickname}`);

  return data;
};
```

<br />

### 2️⃣ mutation에 여러 개의 query key 적용
- queryClient에 invalidateQueries를 하면 쿼리 키에 해당하는 데이터가 변했다면 최신 데이터로 패칭시켜주는데요,
쿼리 키를 여러 개 지정한다면 원래 키를 지정하는 방식대로 하나의 배열 안에 키를 넣어주면 된다고 생각했어요 !
```typscript
queryClient.invalidateQueries({ queryKey: ['get-follower-summary', 'get-user-profile', ...] });
```

- 그런데 예상과는 달리 이렇게 하니까 데이터 패칭이 잘 이뤄지지 않더라구요, 공식 문서를 찾아보니 방법은 간단했습니당
단순히 여러 개의 invalidateQueries를 작성해주니 잘 동작했어요
```typscript
queryClient.invalidateQueries({ queryKey: ['get-follower-summary'] });
queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
...
```

**참고** 🔗: https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations
