### PR TITLE
[ Home ] Home API 부분 연결 

### DIFF
--- a/src/common/CommonMonthSolve.tsx
+++ b/src/common/CommonMonthSolve.tsx
@@ -1,12 +1,43 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import CommonCalendar from '../components/Calendar/Calendar';
+import useGetMonthSolve from '../libs/hooks/Home/useGetMonthSolve';
 
 const CommonMonthSolve = () => {
   const currentMonth = new Date().getMonth() + 1; // getMonth()는 0부터 시작하므로 +1 필요
   const monthText = `${currentMonth}월 문제풀이 현황`;
   const TotalSolve = 13;
   const LongestSolveDay = 3;
-  const LongestSolvedCount = 2;
+
+  const [totalCount, setTotalCount] = useState(0);
+  const [longestPeriod, setLongestPeriod] = useState(0);
+  const year = new Date().getFullYear();
+  const [clickedYear, setClickedYear] = useState(year);
+  const [clickedMonth, setClickedMonth] = useState(currentMonth);
+
+  const { data } = useGetMonthSolve({
+    year: clickedYear,
+    month: clickedMonth,
+  });
+
+  const upDatedTotalCount = () => {
+    if (data) {
+      const { totalCount } = data.data;
+      setTotalCount(totalCount);
+    }
+  };
+
+  const upDatedLongestPeriod = () => {
+    if (data) {
+      const { longestPeriod } = data.data;
+      setLongestPeriod(longestPeriod);
+    }
+  };
+
+  useEffect(() => {
+    upDatedTotalCount();
+    upDatedLongestPeriod();
+  }, [data]);
 
   return (
     <WeekRateContainer>
@@ -19,14 +50,20 @@ const CommonMonthSolve = () => {
           </SolveCount>
         </SolveContainer>
         <LongestSolve>
-          최장 문제 풀이 기간 <Text>{LongestSolveDay}</Text>일
+          최장 문제 풀이 기간 <Text>{longestPeriod}</Text>일
         </LongestSolve>
         <LongestSolve>
-          최장 문제 풀이 개수 <Text>{LongestSolvedCount}</Text>개
+          최대 문제 풀이 개수 <Text>{totalCount}</Text>개
         </LongestSolve>
       </div>
 
-      <CommonCalendar />
+      <CommonCalendar
+        clickedYear={clickedYear}
+        clickedMonth={clickedMonth}
+        data={data}
+        setClickedYear={setClickedYear}
+        setClickedMonth={setClickedMonth}
+      />
     </WeekRateContainer>
   );
 };

--- a/src/common/CommonMonthSolve.tsx
+++ b/src/common/CommonMonthSolve.tsx
@@ -6,11 +6,13 @@ import useGetMonthSolve from '../libs/hooks/Home/useGetMonthSolve';
 const CommonMonthSolve = () => {
   const currentMonth = new Date().getMonth() + 1; // getMonth()는 0부터 시작하므로 +1 필요
   const monthText = `${currentMonth}월 문제풀이 현황`;
-  const TotalSolve = 13;
-  const LongestSolveDay = 3;
 
-  const [totalCount, setTotalCount] = useState(0);
-  const [longestPeriod, setLongestPeriod] = useState(0);
+  const [stats, setStats] = useState({
+    totalCount: 0,
+    longestPeriod: 0,
+    maxCount: 0,
+  });
+
   const year = new Date().getFullYear();
   const [clickedYear, setClickedYear] = useState(year);
   const [clickedMonth, setClickedMonth] = useState(currentMonth);
@@ -20,23 +22,15 @@ const CommonMonthSolve = () => {
     month: clickedMonth,
   });
 
-  const upDatedTotalCount = () => {
-    if (data) {
-      const { totalCount } = data.data;
-      setTotalCount(totalCount);
-    }
-  };
-
-  const upDatedLongestPeriod = () => {
-    if (data) {
-      const { longestPeriod } = data.data;
-      setLongestPeriod(longestPeriod);
-    }
-  };
-
   useEffect(() => {
-    upDatedTotalCount();
-    upDatedLongestPeriod();
+    if (data) {
+      const { totalCount, longestPeriod, maxCount } = data.data;
+      setStats({
+        totalCount,
+        longestPeriod,
+        maxCount,
+      });
+    }
   }, [data]);
 
   return (
@@ -45,15 +39,15 @@ const CommonMonthSolve = () => {
         <Month>{monthText}</Month>
         <SolveContainer>
           <SolveCount>
-            {TotalSolve}
+            {stats.totalCount}
             <SolveCountText>문제</SolveCountText>
           </SolveCount>
         </SolveContainer>
         <LongestSolve>
-          최장 문제 풀이 기간 <Text>{longestPeriod}</Text>일
+          최장 문제 풀이 기간 <Text>{stats.longestPeriod}</Text>일
         </LongestSolve>
         <LongestSolve>
-          최대 문제 풀이 개수 <Text>{totalCount}</Text>개
+          최대 문제 풀이 개수 <Text>{stats.maxCount}</Text>개
         </LongestSolve>
       </div>
 

--- a/src/common/CommonMonthSolve.tsx
+++ b/src/common/CommonMonthSolve.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import CommonCalendar from '../components/Calendar/Calendar';
 import useGetMonthSolve from '../libs/hooks/Home/useGetMonthSolve';
@@ -7,31 +7,16 @@ const CommonMonthSolve = () => {
   const currentMonth = new Date().getMonth() + 1; // getMonth()는 0부터 시작하므로 +1 필요
   const monthText = `${currentMonth}월 문제풀이 현황`;
 
-  const [stats, setStats] = useState({
-    totalCount: 0,
-    longestPeriod: 0,
-    maxCount: 0,
-  });
-
   const year = new Date().getFullYear();
   const [clickedYear, setClickedYear] = useState(year);
   const [clickedMonth, setClickedMonth] = useState(currentMonth);
 
-  const { data } = useGetMonthSolve({
+  const { data, isLoading } = useGetMonthSolve({
     year: clickedYear,
     month: clickedMonth,
   });
 
-  useEffect(() => {
-    if (data) {
-      const { totalCount, longestPeriod, maxCount } = data.data;
-      setStats({
-        totalCount,
-        longestPeriod,
-        maxCount,
-      });
-    }
-  }, [data]);
+  const { totalCount, longestPeriod, maxCount } = !isLoading && data?.data;
 
   return (
     <WeekRateContainer>
@@ -39,15 +24,15 @@ const CommonMonthSolve = () => {
         <Month>{monthText}</Month>
         <SolveContainer>
           <SolveCount>
-            {stats.totalCount}
+            {totalCount}
             <SolveCountText>문제</SolveCountText>
           </SolveCount>
         </SolveContainer>
         <LongestSolve>
-          최장 문제 풀이 기간 <Text>{stats.longestPeriod}</Text>일
+          최장 문제 풀이 기간 <Text>{longestPeriod}</Text>일
         </LongestSolve>
         <LongestSolve>
-          최대 문제 풀이 개수 <Text>{stats.maxCount}</Text>개
+          최대 문제 풀이 개수 <Text>{maxCount}</Text>개
         </LongestSolve>
       </div>
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -102,7 +102,6 @@ const CommonCalendar = ({
               return solvedDay ? 'solved' : null;
             }
           }
-          return null;
         }}
       />
     </CalendarContainer>

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -35,14 +35,8 @@ const CommonCalendar = ({
   setClickedMonth,
 }: CommonCalendarProps) => {
   const today = new Date();
-  // const year = today.getFullYear();
-  // const month = today.getMonth() + 1;
-  // const day = today.getDate();
-  // const [clickedYear, setClickedYear] = useState(year);
-  // const [clickedMonth, setClickedMonth] = useState(month);
   const [selectedDate, setSelectedDate] = useState<SelectedDate>(today);
   const [board, setBoard] = useState<BoardProps[]>([]);
-  // const [value, onChange] = useState(new Date());
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -5,23 +5,8 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css'; // css import
 import styled from 'styled-components';
 import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
+import { BoardProps, CommonCalendarProps } from '../../types/Home/calendarType';
 import CustomCalendar from './CustomCalendar';
-
-interface BoardProps {
-  date: string;
-  isSolved: boolean;
-}
-interface CommonCalendarProps {
-  clickedYear: number;
-  clickedMonth: number;
-  data: {
-    data: {
-      board: BoardProps[];
-    };
-  };
-  setClickedYear: React.Dispatch<React.SetStateAction<number>>;
-  setClickedMonth: React.Dispatch<React.SetStateAction<number>>;
-}
 
 type ValuePiece = Date | null;
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,4 +1,5 @@
 /* stylelint-disable selector-class-pattern */
+
 import { useEffect, useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css'; // css import
@@ -7,7 +8,7 @@ import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
 import useGetMonthSolve from '../../libs/hooks/Home/useGetMonthSolve';
 import CustomCalendar from './CustomCalendar';
 
-interface CalendarProps {
+interface BoardProps {
   date: string;
   isSolved: boolean;
 }
@@ -19,10 +20,13 @@ type SelectedDate = ValuePiece | [ValuePiece, ValuePiece];
 const CommonCalendar = () => {
   const today = new Date();
   const year = today.getFullYear();
-  const [selectedDate, setSelectedDate] = useState<SelectedDate>(today);
+  const month = today.getMonth() + 1;
+  // const day = today.getDate();
   const [clickedYear, setClickedYear] = useState(year);
-  const [clickedMonth, setClickedMonth] = useState(today.getMonth() + 1);
-  const [board, setBoard] = useState([]);
+  const [clickedMonth, setClickedMonth] = useState(month);
+  const [selectedDate, setSelectedDate] = useState<SelectedDate>(today);
+  const [board, setBoard] = useState<BoardProps[]>([]);
+  // const [value, onChange] = useState(new Date());
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 
@@ -41,7 +45,7 @@ const CommonCalendar = () => {
   };
 
   const handleClickMonth = (month: number) => {
-    const newDate = new Date(clickedYear, month - 1, today.getDate());
+    const newDate = new Date(clickedYear, month - 1);
     setClickedMonth(month);
     setSelectedDate(newDate);
     setIsCalendarClicked(false);
@@ -55,12 +59,16 @@ const CommonCalendar = () => {
   const upDatedCalendar = () => {
     if (data) {
       const { board } = data.data;
+      setBoard(board);
     }
   };
 
   useEffect(() => {
     upDatedCalendar();
-  });
+  }, [data]);
+
+  console.log(selectedDate);
+
   return (
     <CalendarContainer>
       <NavContainer>
@@ -83,14 +91,29 @@ const CommonCalendar = () => {
         ) : (
           <IcArrowBottomWhite onClick={handleClickCalendar} />
         )}
+        \
       </NavContainer>
       <StyledCalendar
-        onChange={(value) => setSelectedDate(value)}
-        locale="ko-KR"
+        onChange={setSelectedDate}
+        locale="ko"
         value={selectedDate}
         showNeighboringMonth={true}
         formatShortWeekday={(_, date) => customWeekdays[date.getDay()]}
         showNavigation={false}
+        tileClassName={({ date, view }) => {
+          if (view === 'month') {
+            const day = date.getDate().toString();
+            const month = date.getMonth() + 1;
+            const year = date.getFullYear();
+
+            // 현재 달의 날짜인지 확인
+            if (month === clickedMonth && year === clickedYear) {
+              const solvedDay = board.find((d) => d.date === day && d.isSolved);
+              return solvedDay ? 'solved' : null;
+            }
+          }
+          return null;
+        }}
       />
     </CalendarContainer>
   );
@@ -148,6 +171,7 @@ const Month = styled.p`
 const CustomCalendarContainer = styled.div`
   left: 0;
 `;
+
 const StyledCalendar = styled(Calendar)`
   /* stylelint-disable-next-line selector-class-pattern */
   .react-calendar__tile {
@@ -159,6 +183,10 @@ const StyledCalendar = styled(Calendar)`
     color: ${({ theme }) => theme.colors.gray500};
 
     ${({ theme }) => theme.fonts.body_medium_16};
+    &.solved {
+      background-color: ${({ theme }) => theme.colors.codrive_green};
+    }
+
     abbr {
       position: absolute;
       overflow: hidden;
@@ -191,11 +219,24 @@ const StyledCalendar = styled(Calendar)`
   }
 
   /* stylelint-disable-next-line selector-class-pattern */
-  .react-calendar__tile:enabled:hover {
-    background-color: ${({ theme }) => theme.colors.gray500};
-  }
-  /* stylelint-disable-next-line selector-class-pattern */
   .react-calendar__tile:enabled:focus {
+    background-color: ${({ theme }) => theme.colors.gray500};
+
+    &.solved {
+      background-color: ${({ theme }) => theme.colors.codrive_green};
+    }
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .react-calendar__tile:enabled:hover {
+    &:enabled:hover {
+      background-color: ${({ theme }) => theme.colors.gray500};
+    }
+
+    &.solved:enabled:hover {
+      background-color: ${({ theme }) => theme.colors.codrive_green};
+    }
+
     background-color: ${({ theme }) => theme.colors.gray500};
   }
 `;

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,10 +1,16 @@
 /* stylelint-disable selector-class-pattern */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css'; // css import
 import styled from 'styled-components';
 import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
+import useGetMonthSolve from '../../libs/hooks/Home/useGetMonthSolve';
 import CustomCalendar from './CustomCalendar';
+
+interface CalendarProps {
+  date: string;
+  isSolved: boolean;
+}
 
 type ValuePiece = Date | null;
 
@@ -16,6 +22,7 @@ const CommonCalendar = () => {
   const [selectedDate, setSelectedDate] = useState<SelectedDate>(today);
   const [clickedYear, setClickedYear] = useState(year);
   const [clickedMonth, setClickedMonth] = useState(today.getMonth() + 1);
+  const [board, setBoard] = useState([]);
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 
@@ -40,6 +47,20 @@ const CommonCalendar = () => {
     setIsCalendarClicked(false);
   };
 
+  const { data } = useGetMonthSolve({
+    year: clickedYear,
+    month: clickedMonth,
+  });
+
+  const upDatedCalendar = () => {
+    if (data) {
+      const { board } = data.data;
+    }
+  };
+
+  useEffect(() => {
+    upDatedCalendar();
+  });
   return (
     <CalendarContainer>
       <NavContainer>

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -5,25 +5,41 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css'; // css import
 import styled from 'styled-components';
 import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
-import useGetMonthSolve from '../../libs/hooks/Home/useGetMonthSolve';
 import CustomCalendar from './CustomCalendar';
 
 interface BoardProps {
   date: string;
   isSolved: boolean;
 }
+interface CommonCalendarProps {
+  clickedYear: number;
+  clickedMonth: number;
+  data: {
+    data: {
+      board: BoardProps[];
+    };
+  };
+  setClickedYear: React.Dispatch<React.SetStateAction<number>>;
+  setClickedMonth: React.Dispatch<React.SetStateAction<number>>;
+}
 
 type ValuePiece = Date | null;
 
 type SelectedDate = ValuePiece | [ValuePiece, ValuePiece];
 
-const CommonCalendar = () => {
+const CommonCalendar = ({
+  clickedYear,
+  clickedMonth,
+  data,
+  setClickedYear,
+  setClickedMonth,
+}: CommonCalendarProps) => {
   const today = new Date();
-  const year = today.getFullYear();
-  const month = today.getMonth() + 1;
+  // const year = today.getFullYear();
+  // const month = today.getMonth() + 1;
   // const day = today.getDate();
-  const [clickedYear, setClickedYear] = useState(year);
-  const [clickedMonth, setClickedMonth] = useState(month);
+  // const [clickedYear, setClickedYear] = useState(year);
+  // const [clickedMonth, setClickedMonth] = useState(month);
   const [selectedDate, setSelectedDate] = useState<SelectedDate>(today);
   const [board, setBoard] = useState<BoardProps[]>([]);
   // const [value, onChange] = useState(new Date());
@@ -50,11 +66,6 @@ const CommonCalendar = () => {
     setSelectedDate(newDate);
     setIsCalendarClicked(false);
   };
-
-  const { data } = useGetMonthSolve({
-    year: clickedYear,
-    month: clickedMonth,
-  });
 
   const upDatedCalendar = () => {
     if (data) {
@@ -155,7 +166,7 @@ const DateContainer = styled.div`
   align-items: center;
 
   padding-right: 0.2rem;
-  padding-left: 1.4rem;
+  padding-left: 1.1rem;
 `;
 
 const Year = styled.p`

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -78,7 +78,7 @@ const CommonCalendar = ({
     upDatedCalendar();
   }, [data]);
 
-  console.log(selectedDate);
+  // console.log(selectedDate);
 
   return (
     <CalendarContainer>

--- a/src/components/Home/TodaySolve.tsx
+++ b/src/components/Home/TodaySolve.tsx
@@ -165,6 +165,8 @@ const TitleContainer = styled.div`
 const Title = styled.h2`
   ${({ theme }) => theme.fonts.title_bold_20}
   color: ${({ theme }) => theme.colors.white};
+
+  white-space: nowrap;
 `;
 
 const Subtitle = styled.p`

--- a/src/components/Home/TodaySolve.tsx
+++ b/src/components/Home/TodaySolve.tsx
@@ -1,23 +1,16 @@
+import { useEffect, useState } from 'react';
 import { Cell, Label, Pie, PieChart } from 'recharts';
 import styled from 'styled-components';
 import { BtnInformation } from '../../assets';
-
-interface CustomLabelProps {
-  viewBox: {
-    cx: number;
-    cy: number;
-  };
-  upValue: string | number;
-  downValue: string | number;
-  isDefault: boolean;
-}
+import useGetUserAchieve from '../../libs/hooks/Home/useGetUserAchieve';
+import { TodaySolveProps } from '../../types/Home/todaySolveType';
 
 const CustomLabel = ({
   viewBox,
   upValue,
   downValue,
   isDefault,
-}: CustomLabelProps) => {
+}: TodaySolveProps) => {
   const { cx, cy } = viewBox; // 중심 좌표
   const upValuePadding = isDefault ? 12 : 5;
   const downValuePadding = isDefault ? 12 : 30;
@@ -46,11 +39,24 @@ const CustomLabel = ({
 };
 
 const TodaySolve = () => {
-  const maxProblems = 7; // 나중에 props로 받을 것
-  const solvedProblems = 2; // 나중에 props로 받을 것
+  const [stats, setStats] = useState({
+    goal: 0,
+    todayCount: 0,
+  });
+
+  const data = useGetUserAchieve();
+  useEffect(() => {
+    if (data) {
+      const { goal, todayCount } = data.data;
+      setStats({
+        goal: goal,
+        todayCount: todayCount,
+      });
+    }
+  }, [data]);
 
   const percentage =
-    maxProblems && solvedProblems ? (solvedProblems / maxProblems) * 100 : 10;
+    stats.goal && stats.todayCount ? (stats.todayCount / stats.goal) * 100 : 10;
 
   const chartData = [{ name: 'Solved', value: percentage }];
 
@@ -109,7 +115,7 @@ const TodaySolve = () => {
             <Cell
               key={`cell-1`}
               fill={
-                maxProblems && solvedProblems
+                stats.goal && stats.todayCount
                   ? 'url(#colorGradient)'
                   : '#B2B4BA'
               }
@@ -118,12 +124,12 @@ const TodaySolve = () => {
               content={
                 <CustomLabel
                   upValue={
-                    maxProblems && solvedProblems ? solvedProblems : '목표를'
+                    stats.goal && stats.todayCount ? stats.todayCount : '목표를'
                   }
                   downValue={
-                    maxProblems && solvedProblems ? '문제' : '설정해주세요'
+                    stats.goal && stats.todayCount ? '문제' : '설정해주세요'
                   }
-                  isDefault={maxProblems && solvedProblems ? false : true}
+                  isDefault={stats.goal && stats.todayCount ? false : true}
                   viewBox={{ cx: 0, cy: 0 }}
                 />
               }

--- a/src/components/Home/TodaySolve.tsx
+++ b/src/components/Home/TodaySolve.tsx
@@ -54,8 +54,6 @@ const TodaySolve = () => {
 
   const chartData = [{ name: 'Solved', value: percentage }];
 
-  console.log(chartData[0]);
-
   return (
     <Container>
       <TitleContainer>

--- a/src/components/Home/WeekFollowing/ProfileCard.tsx
+++ b/src/components/Home/WeekFollowing/ProfileCard.tsx
@@ -20,7 +20,6 @@ const CustomLabel = ({ profileImg }: CustomLabelProps) => {
 
 const HomeProfileCard = ({ user }: HomeProfileCardProps) => {
   const { userId, successRate, profileImg, nickname, language } = user;
-  console.log(user);
 
   // nickname과 language의 존재 여부에 따라 기본값 설정
   let NickName = nickname;

--- a/src/components/Home/WeekFollowing/ProfileCard.tsx
+++ b/src/components/Home/WeekFollowing/ProfileCard.tsx
@@ -102,8 +102,6 @@ const LanguageText = styled.div`
 
   margin-top: 0.8rem;
 
-  /* margin-bottom: 4.1rem; */
-
   color: ${({ theme }) => theme.colors.gray400};
   ${({ theme }) => theme.fonts.body_eng_regular_14};
 `;

--- a/src/components/Home/WeekFollowing/ProfileCard.tsx
+++ b/src/components/Home/WeekFollowing/ProfileCard.tsx
@@ -20,12 +20,15 @@ const CustomLabel = ({ profileImg }: CustomLabelProps) => {
 
 const HomeProfileCard = ({ user }: HomeProfileCardProps) => {
   const { userId, successRate, profileImg, nickname, language } = user;
-  console.log('성공률 :', successRate, '이미지 :', profileImg);
+  console.log(user);
 
+  // nickname과 language의 존재 여부에 따라 기본값 설정
   let NickName = nickname;
   if (nickname.length > 7) {
     NickName = nickname.slice(0, 7) + '...';
   }
+
+  const Language = language && language.length > 0 ? language : '사용언어';
 
   const chartData = [
     { name: 'Success', value: successRate === 0 ? 10 : successRate },
@@ -36,39 +39,76 @@ const HomeProfileCard = ({ user }: HomeProfileCardProps) => {
   return (
     <>
       <FollowerContainer key={userId}>
-        <PieChart width={76} height={76}>
-          <Pie
-            dataKey="value"
-            data={chartData}
-            startAngle={90}
-            endAngle={-270}
-            innerRadius={33}
-            outerRadius={38}
-            paddingAngle={0}
-            cornerRadius={15}
-            fill="#494B53"
-            stroke="none"
-          ></Pie>
-          <Pie
-            data={chartData}
-            dataKey="value"
-            endAngle={endAngle}
-            startAngle={90}
-            outerRadius={38}
-            innerRadius={33}
-            paddingAngle={0}
-            stroke="none"
-            cornerRadius={15}
-          >
-            <Cell key="success" fill="#BF57FF" />
-            <Label
-              content={<CustomLabel profileImg={profileImg} />}
-              position="center"
-            />
-          </Pie>
-        </PieChart>
-        <Text>{NickName}</Text>
-        <LanguageText>#{language}</LanguageText>
+        {user ? (
+          <PieContainer>
+            <PieChart width={76} height={76}>
+              <Pie
+                dataKey="value"
+                data={chartData}
+                startAngle={90}
+                endAngle={-270}
+                innerRadius={33}
+                outerRadius={38}
+                paddingAngle={0}
+                cornerRadius={15}
+                fill="#494B53"
+                stroke="none"
+              >
+                <Label
+                  content={<CustomLabel profileImg={profileImg} />}
+                  position="center"
+                />
+              </Pie>
+              <Pie
+                data={chartData}
+                dataKey="value"
+                endAngle={endAngle}
+                startAngle={90}
+                outerRadius={38}
+                innerRadius={33}
+                paddingAngle={0}
+                stroke="none"
+                cornerRadius={15}
+              >
+                <Cell key="success" fill="#BF57FF" />
+                <Label
+                  content={<CustomLabel profileImg={profileImg} />}
+                  position="center"
+                />
+              </Pie>
+            </PieChart>
+            <Text>{NickName}</Text>
+            <LanguageText>#{Language}</LanguageText>
+          </PieContainer>
+        ) : (
+          <PieContainer>
+            <PieChart width={76} height={76}>
+              <Pie
+                data={[{ name: 'Gray Circle', value: 100 }]}
+                dataKey="value"
+                startAngle={0}
+                endAngle={360}
+                outerRadius={30}
+                fill="#292A2F"
+                stroke="none"
+              />
+              <Pie
+                dataKey="value"
+                data={[{ name: 'Empty', value: 100 }]} // 빈 차트를 위한 데이터
+                startAngle={90}
+                endAngle={-270}
+                innerRadius={33}
+                outerRadius={38}
+                paddingAngle={0}
+                cornerRadius={15}
+                fill="#494B53"
+                stroke="none"
+              />
+            </PieChart>
+            <Text>기본사용자</Text>
+            <LanguageText>#사용언어</LanguageText>
+          </PieContainer>
+        )}
       </FollowerContainer>
     </>
   );
@@ -78,8 +118,15 @@ export default HomeProfileCard;
 
 const FollowerContainer = styled.div`
   display: flex;
+  gap: 2rem;
   align-items: center;
-  flex-direction: column;
+  flex-direction: row;
+`;
+
+const PieContainer = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column; /* Pie와 텍스트를 세로로 배치 */
 `;
 
 const Text = styled.div`

--- a/src/components/Home/WeekFollowing/ProfileCard.tsx
+++ b/src/components/Home/WeekFollowing/ProfileCard.tsx
@@ -20,13 +20,18 @@ const CustomLabel = ({ profileImg }: CustomLabelProps) => {
 
 const HomeProfileCard = ({ user }: HomeProfileCardProps) => {
   const { userId, successRate, profileImg, nickname, language } = user;
+  console.log('성공률 :', successRate, '이미지 :', profileImg);
 
   let NickName = nickname;
   if (nickname.length > 7) {
     NickName = nickname.slice(0, 7) + '...';
   }
 
-  const chartData = [{ name: 'Success', value: successRate }];
+  const chartData = [
+    { name: 'Success', value: successRate === 0 ? 10 : successRate },
+  ];
+
+  const endAngle = 90 - (360 * chartData[0].value) / 100;
 
   return (
     <>
@@ -47,7 +52,7 @@ const HomeProfileCard = ({ user }: HomeProfileCardProps) => {
           <Pie
             data={chartData}
             dataKey="value"
-            endAngle={90 - (360 * successRate) / 100}
+            endAngle={endAngle}
             startAngle={90}
             outerRadius={38}
             innerRadius={33}

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -12,7 +12,6 @@ const WeeklyFollower = () => {
   const { data, isLoading } = useGetFollowingsCheck();
   const { followings } = !isLoading && data.data;
   const isFollowing = false;
-  console.log(followings);
 
   const hasFollowers = !isLoading && followings.length > 0;
 

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -1,12 +1,18 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowRightGray } from '../../../assets';
-import { Home_FOLLOWER_DUMMY } from '../../../constants/Home/follwerConst';
+import useGetFollowingsCheck from '../../../libs/hooks/Home/useGetFollowingsCheck';
 import HomeProfileCard from './ProfileCard';
 
+import { UserProps } from '../../../types/Week/HomeFollowerTypes';
+
 const WeeklyFollower = () => {
-  const hasFollowers = Home_FOLLOWER_DUMMY.followings.length > 0;
   const navigate = useNavigate();
+
+  const { data, isLoading } = useGetFollowingsCheck();
+  const { followings } = !isLoading && data.data;
+  // const hasFollowers = followings.length > 0; // ! hasFollowers 를 사용했을 떄 렌더링이 되질 않음(length undefiend)
+  console.log(followings);
 
   const handleClickAllButton = () => {
     navigate('/follower');
@@ -24,10 +30,12 @@ const WeeklyFollower = () => {
         </div>
       </HeaderContainer>
       <ProfileContainer>
-        {hasFollowers ? (
-          Home_FOLLOWER_DUMMY.followings
+        {!isLoading && followings.length > 0 ? (
+          followings
             .slice(0, 3)
-            .map((user) => <HomeProfileCard key={user.userId} user={user} />)
+            .map((user: UserProps) => (
+              <HomeProfileCard key={user.userId} user={user} />
+            ))
         ) : (
           <NoFollowersText>
             팔로워를 추가하여 <br /> 문제풀이 현황을 비교해보세요

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -11,6 +11,8 @@ const WeeklyFollower = () => {
 
   const { data, isLoading } = useGetFollowingsCheck();
   const { followings } = !isLoading && data.data;
+  const isFollowing = false;
+
   // const hasFollowers = followings.length > 0; // ! hasFollowers 를 사용했을 떄 렌더링이 되질 않음(length undefiend)
   console.log(followings);
 
@@ -29,7 +31,7 @@ const WeeklyFollower = () => {
           </AllButton>
         </div>
       </HeaderContainer>
-      <ProfileContainer>
+      <ProfileContainer $isFollowing={isFollowing}>
         {!isLoading && followings.length > 0 ? (
           followings
             .slice(0, 3)
@@ -64,9 +66,12 @@ const HeaderContainer = styled.div`
   white-space: nowrap;
 `;
 
-const ProfileContainer = styled.div`
+const ProfileContainer = styled.div<{ $isFollowing: boolean }>`
   display: flex;
   gap: 2.4rem;
+  justify-content: ${({ $isFollowing }) => ($isFollowing ? 'start' : 'center')};
+
+  /* justify-content: center; */
   align-items: center;
 
   margin: 4rem 0 4.1rem;

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -67,11 +67,9 @@ const HeaderContainer = styled.div`
 const ProfileContainer = styled.div`
   display: flex;
   gap: 2.4rem;
-  justify-content: center;
   align-items: center;
 
   margin: 4rem 0 4.1rem;
-  margin-top: 4rem;
 `;
 
 const NoFollowersText = styled.p`

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -12,9 +12,9 @@ const WeeklyFollower = () => {
   const { data, isLoading } = useGetFollowingsCheck();
   const { followings } = !isLoading && data.data;
   const isFollowing = false;
-
-  // const hasFollowers = followings.length > 0; // ! hasFollowers 를 사용했을 떄 렌더링이 되질 않음(length undefiend)
   console.log(followings);
+
+  const hasFollowers = !isLoading && followings.length > 0;
 
   const handleClickAllButton = () => {
     navigate('/follower');
@@ -32,7 +32,7 @@ const WeeklyFollower = () => {
         </div>
       </HeaderContainer>
       <ProfileContainer $isFollowing={isFollowing}>
-        {!isLoading && followings.length > 0 ? (
+        {!isLoading && hasFollowers ? (
           followings
             .slice(0, 3)
             .map((user: UserProps) => (
@@ -70,8 +70,6 @@ const ProfileContainer = styled.div<{ $isFollowing: boolean }>`
   display: flex;
   gap: 2.4rem;
   justify-content: ${({ $isFollowing }) => ($isFollowing ? 'start' : 'center')};
-
-  /* justify-content: center; */
   align-items: center;
 
   margin: 4rem 0 4.1rem;

--- a/src/components/Home/WeekRate.tsx
+++ b/src/components/Home/WeekRate.tsx
@@ -19,11 +19,21 @@ const CustomLabel = ({ viewBox, value }: WeekRateProps) => {
   );
 };
 const WeekRate = () => {
-  const maxProblems = 0;
-  const solvedProblems = 0;
+  const maxProblems = 7;
+  const solvedProblems = 7;
 
-  const percentage =
-    maxProblems && solvedProblems ? (solvedProblems / maxProblems) * 100 : 10;
+  const percentagePerProblem = Array.from({ length: maxProblems }, (_, i) => {
+    if (i === maxProblems - 1) {
+      return 100;
+    } else {
+      return ((i + 1) * 100) / maxProblems;
+    }
+  });
+
+  const percentage = percentagePerProblem[solvedProblems - 1] || 0;
+
+  console.log(percentage);
+
   const chartData = [{ name: 'Solved', value: percentage }];
   const endAngle = 180 - (percentage / 100) * 180;
   return (

--- a/src/components/Home/WeekRate.tsx
+++ b/src/components/Home/WeekRate.tsx
@@ -102,7 +102,9 @@ const WeekRate = () => {
           <>
             <Message>축하해요!</Message>
             <Message>
-              지난 주보다 {stats.weeklyCountDifference}문제 더 풀었어요!
+              {stats.weeklyCountDifference < 0
+                ? `지난 주보다 0문제 더 풀었어요!`
+                : `지난 주보다 ${stats.weeklyCountDifference}문제 더 풀었어요!`}
             </Message>
           </>
         ) : (

--- a/src/components/Home/WeekRate.tsx
+++ b/src/components/Home/WeekRate.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react';
 import { Cell, Label, Pie, PieChart } from 'recharts';
 import styled from 'styled-components';
+import useGetUserAchieve from '../../libs/hooks/Home/useGetUserAchieve';
 import { WeekRateProps } from '../../types/Week/weekRateTypes';
 
 const CustomLabel = ({ viewBox, value }: WeekRateProps) => {
@@ -19,20 +21,23 @@ const CustomLabel = ({ viewBox, value }: WeekRateProps) => {
   );
 };
 const WeekRate = () => {
-  const maxProblems = 7;
-  const solvedProblems = 7;
-
-  const percentagePerProblem = Array.from({ length: maxProblems }, (_, i) => {
-    if (i === maxProblems - 1) {
-      return 100;
-    } else {
-      return ((i + 1) * 100) / maxProblems;
-    }
+  const [stats, setStats] = useState({
+    successRate: 0,
+    weeklyCountDifference: 0,
   });
 
-  const percentage = percentagePerProblem[solvedProblems - 1] || 0;
+  const percentage = stats.successRate || 0;
 
-  console.log(percentage);
+  const data = useGetUserAchieve();
+  useEffect(() => {
+    if (data) {
+      const { successRate, weeklyCountDifference } = data.data;
+      setStats({
+        successRate: successRate,
+        weeklyCountDifference: weeklyCountDifference,
+      });
+    }
+  }, [data]);
 
   const chartData = [{ name: 'Solved', value: percentage }];
   const endAngle = 180 - (percentage / 100) * 180;
@@ -66,9 +71,7 @@ const WeekRate = () => {
               content={
                 <CustomLabel
                   value={
-                    maxProblems && solvedProblems
-                      ? `${percentage.toFixed(0)}%`
-                      : `${0}%`
+                    stats.successRate ? `${percentage.toFixed(0)}%` : `${0}%`
                   }
                   viewBox={{ cx: 0, cy: 100 }}
                 />
@@ -93,10 +96,12 @@ const WeekRate = () => {
         </PieChart>
       </ChartContainer>
       <MessageContainer>
-        {maxProblems && solvedProblems ? (
+        {stats.successRate ? (
           <>
             <Message>축하해요!</Message>
-            <Message>지난 주보다 {solvedProblems}문제 더 풀었어요!</Message>
+            <Message>
+              지난 주보다 {stats.weeklyCountDifference}문제 더 풀었어요!
+            </Message>
           </>
         ) : (
           <>
@@ -130,12 +135,10 @@ const ChartContainer = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-
-  /* background-color: beige; */
 `;
 
 const StyledText = styled.text`
-  fill: #fff;
+  fill: ${({ theme }) => theme.colors.white};
 
   ${({ theme }) => theme.fonts.title_bold_32};
   background-color: pink;

--- a/src/components/Home/WeekRate.tsx
+++ b/src/components/Home/WeekRate.tsx
@@ -39,8 +39,10 @@ const WeekRate = () => {
     }
   }, [data]);
 
-  const chartData = [{ name: 'Solved', value: percentage }];
-  const endAngle = 180 - (percentage / 100) * 180;
+  const chartData = [
+    { name: 'Solved', value: percentage === 0 ? 10 : percentage },
+  ];
+  const endAngle = 180 - (chartData[0].value / 100) * 180;
   return (
     <Container>
       <Header>주간 성과율</Header>

--- a/src/libs/apis/Home/getFollowingsCheck.ts
+++ b/src/libs/apis/Home/getFollowingsCheck.ts
@@ -1,0 +1,9 @@
+import { api } from '../../api';
+
+const getFollowingsCheck = async () => {
+  const { data } = await api.get(`/follow/followings/weekly`);
+
+  return data;
+};
+
+export default getFollowingsCheck;

--- a/src/libs/apis/Home/getMonthSolve.ts
+++ b/src/libs/apis/Home/getMonthSolve.ts
@@ -1,0 +1,14 @@
+import { getMonthSolveProps } from '../../../types/Home/getMonthSolveTypes';
+import { api } from '../../api';
+
+const getMonthSolve = async ({ year, month }: getMonthSolveProps) => {
+  const userId = sessionStorage.getItem('user');
+  const formatMonth = month < 10 ? `0${month}` : `${month}`;
+  const { data } = await api.get(
+    `/records/${userId}/board?pivotDate=${year}-${formatMonth}-01`
+  );
+
+  return data;
+};
+
+export default getMonthSolve;

--- a/src/libs/apis/Home/getUserAchieve.ts
+++ b/src/libs/apis/Home/getUserAchieve.ts
@@ -1,0 +1,9 @@
+import { api } from '../../api';
+
+const getUserAchieve = async () => {
+  const { data } = await api.get(`/users/achieve`);
+
+  return data;
+};
+
+export default getUserAchieve;

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -9,8 +9,9 @@ export const getMonthlySolution = async ({
   isSmallList,
 }: getMonthlySolutionProps) => {
   const userId = sessionStorage.getItem('user');
+  const formatMonth = month < 10 ? `0${month}` : `${month}`;
   const { data } = await api.get(
-    `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-0${month}-01&page=${page}&size=${isSmallList ? 5 : 7}`
+    `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=${isSmallList ? 5 : 7}`
   );
 
   return data;

--- a/src/libs/hooks/Home/useGetFollowingsCheck.ts
+++ b/src/libs/hooks/Home/useGetFollowingsCheck.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import getFollowingsCheck from '../../apis/Home/getFollowingsCheck';
+
+const useGetFollowingsCheck = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['get-followings-check'],
+    queryFn: async () => await getFollowingsCheck(),
+  });
+
+  return { data, isLoading };
+};
+
+export default useGetFollowingsCheck;

--- a/src/libs/hooks/Home/useGetMonthSolve.ts
+++ b/src/libs/hooks/Home/useGetMonthSolve.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMonthSolveProps } from '../../../types/Home/getMonthSolveTypes';
+import getMonthSolve from '../../apis/Home/getMonthSolve';
+
+const useGetMonthSolve = ({ year, month }: getMonthSolveProps) => {
+  const data = useQuery({
+    queryKey: ['get-month-solve', year, month],
+    queryFn: async () => await getMonthSolve({ year, month }),
+  });
+
+  return data;
+};
+
+export default useGetMonthSolve;

--- a/src/libs/hooks/Home/useGetUserAchieve.ts
+++ b/src/libs/hooks/Home/useGetUserAchieve.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import getUserAchieve from '../../apis/Home/getUserAchieve';
 
 const useGetUserAchieve = () => {
-  const data = useQuery({
+  const { data } = useQuery({
     queryKey: ['get-user-achieve'],
     queryFn: async () => await getUserAchieve(),
   });

--- a/src/libs/hooks/Home/useGetUserAchieve.ts
+++ b/src/libs/hooks/Home/useGetUserAchieve.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import getUserAchieve from '../../apis/Home/getUserAchieve';
+
+const useGetUserAchieve = () => {
+  const data = useQuery({
+    queryKey: ['get-user-achieve'],
+    queryFn: async () => await getUserAchieve(),
+  });
+
+  return data;
+};
+
+export default useGetUserAchieve;

--- a/src/types/Home/calendarType.ts
+++ b/src/types/Home/calendarType.ts
@@ -1,0 +1,15 @@
+export interface BoardProps {
+  date: string;
+  isSolved: boolean;
+}
+export interface CommonCalendarProps {
+  clickedYear: number;
+  clickedMonth: number;
+  data: {
+    data: {
+      board: BoardProps[];
+    };
+  };
+  setClickedYear: React.Dispatch<React.SetStateAction<number>>;
+  setClickedMonth: React.Dispatch<React.SetStateAction<number>>;
+}

--- a/src/types/Home/getMonthSolveTypes.ts
+++ b/src/types/Home/getMonthSolveTypes.ts
@@ -1,0 +1,4 @@
+export interface getMonthSolveProps {
+  year: number;
+  month: number;
+}

--- a/src/types/Home/todaySolveType.ts
+++ b/src/types/Home/todaySolveType.ts
@@ -1,0 +1,9 @@
+export interface TodaySolveProps {
+  viewBox: {
+    cx: number;
+    cy: number;
+  };
+  upValue: string | number;
+  downValue: string | number;
+  isDefault: boolean;
+}

--- a/src/types/Week/HomeFollowerTypes.ts
+++ b/src/types/Week/HomeFollowerTypes.ts
@@ -11,3 +11,11 @@ export interface HomeProfileCardProps {
 export interface CustomLabelProps {
   profileImg: string;
 }
+
+export interface UserProps {
+  userId: number;
+  successRate: number;
+  profileImg: string;
+  nickname: string;
+  language: string;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #170 

## ✅ 작업 내용

- [x] 문제 풀이 현황 API
- [x] 오늘 문제풀이 & 주간성과율 API
- [x] 주간 팔로잉 API

## 📸 스크린샷 / GIF / Link
<img width="626" alt="image" src="https://github.com/user-attachments/assets/0158c4e8-f1ac-4a58-95b2-51b96066381c">


## 📌 이슈 사항

### 1️⃣ 월 문제 풀이 현황 

파라미터로 userID 값과 pivotDate 가 들어갑니다. userID 는 세션에서 가져오면서 해결하고, pivotDate 는 쿼리 파라미터를 이용하여 전달을 해주었습니다.

```jsx
const getMonthSolve = async ({ year, month }: getMonthSolveProps) => {
  const userId = sessionStorage.getItem('user');
  const formatMonth = month < 10 ? `0${month}` : `${month}`;
  const { data } = await api.get(
    `/records/${userId}/board?pivotDate=${year}-${formatMonth}-01`
  );
```

또한 totalCount, longestPeriod, maxCount 값이 바뀔떄마다 리렌더링이 되어야 하기 때문에 useEffect를 사용하였습니다.

```jsx
const { data } = useGetMonthSolve({
    year: clickedYear,
    month: clickedMonth,
  });

  useEffect(() => {
    if (data) {
      const { totalCount, longestPeriod, maxCount } = data.data;
      setStats({
        totalCount,
        longestPeriod,
        maxCount,
      });
    }
  }, [data]);
```
### 2️⃣ 사용자 성과 조회

파라미터 값으로 아무것도 받지 않음으로 스웨거에 있는 그대로 작성하였습니다. 

```jsx
const getUserAchieve = async () => {
  const { data } = await api.get(`/users/achieve`);

  return data;
};
export default getUserAchieve;
```
};

마찬가지로 리렌더링이 될 떄 마다 값이 바껴야 하기 때문에 useEffect 를 사용하여 값을 변경해주었습니다.
또한 state 값이 중북되는게 많아 한번에 묶어서 사용하였습니다 .
```jsx
const [stats, setStats] = useState({
    successRate: 0,
    weeklyCountDifference: 0,
  });
```
```jsx
const data = useGetUserAchieve();
  useEffect(() => {
    if (data) {
      const { successRate, weeklyCountDifference } = data.data;
      setStats({
        successRate: successRate,
        weeklyCountDifference: weeklyCountDifference,
      });
    }
  }, [data]);
```

### 3️⃣ 오늘 문제 풀이 조회

이것 또한 마찬가지로 리렌더링이 될 떄마다 값이 바껴야 하기 때문에 useEffect를 사용하였고 state 값이 중복되는게 많아 state를 한번에 묶어서 사용하였습니다.

```jsx
  const [stats, setStats] = useState({
    goal: 0,
    todayCount: 0,
  });

  const data = useGetUserAchieve();
  useEffect(() => {
    if (data) {
      const { goal, todayCount } = data.data;
      setStats({
        goal: goal,
        todayCount: todayCount,
      });
    }
  }, [data]);
```

### 4️⃣ 팔로잉 유저 현황 조회

API 는 파라미터로 받는 값도 없고 스웨거 그대로 받아왔습니다.

```jsx
const getFollowingsCheck = async () => {
  const { data } = await api.get(`/follow/followings/weekly`);

  return data;
};
````
***isLoading query 사용***
```jsx
const { data, isLoading } = useGetFollowingsCheck();
  const { followings } = !isLoading && data.data;
  // const hasFollowers = followings.length > 0; // ! hasFollowers 를 사용했을 떄 렌더링이 되질 않음(length undefiend)
  console.log(followings);
```
```jsx
const useGetFollowingsCheck = () => {
  const { data, isLoading } = useQuery({
    queryKey: ['get-followings-check'],
    queryFn: async () => await getFollowingsCheck(),
  });

  return { data, isLoading };
};
```

data 안에 들어있는 followings 라는 배열을 받아온 후 , 값을 뿌려줘야 하는데 여기서 시간을 많이 잡아먹었습니다. React 컴포넌트가 처음 렌더링될 때, useGetFollowingsCheck()로 데이터를 가져오기 전에는 data가 아직 정의되지 않았기 때문에 data.data를 읽으려고 하면 오류가 발생합니다. 떄문에 조건부 렌더링을 걸어줘야 합니다. 

결국에는 following을 찍어보려면 조건부 렌더링이 있어야 하는데, 어떻게 해야할까 하다 useQuery 에서 제공하는 isLoading 이라는 훅의 반환값을 사용하였습니다. 아름이 코드에서 나랑 비슷한 API 를 사용한 흔적이 있는데 나와의 차이점은 isLoading 을 사용을 했냐 안했냐의 차이점이였습니다. 이걸 대체 왜 넣은거지..? 라는 생각을 갖고 아름이가 사용한 훅의 사용처를 보고 찾아보았습니다. 

- **isLoading**: `캐싱 된 데이터가 없을 때` 즉, 처음 실행된 쿼리일 때 로딩 여부에 따라 `true/false`로 반환된다.
    - 이는 캐싱 된 데이터가 있다면 로딩 여부에 상관없이 `false`를 반환한다.
    - `isFetching && isPending` 와 동일하다.

즉 !isLoading 은 isLoading이 false일 때, 쿼리 요청이 완료되어 로딩이 끝났을 떄를 의미한다. 따라서 로딩이 완료되었고, 데이터가 정상적으로 로드되었을 때만 data.data 의 접근하겠다는 의미입니다.

```jsx
{!isLoading && followings.length > 0 ? (
          followings
            .slice(0, 3)
            .map((user: UserProps) => (
              <HomeProfileCard key={user.userId} user={user} />
            ))
        ) : (
          <NoFollowersText>
            팔로워를 추가하여 <br /> 문제풀이 현황을 비교해보세요
          </NoFollowersText>
        )}
```

또한 아름이 코드를 보고  isLoading이 false일 때, 즉, 쿼리 요청이 완료되어 로딩이 끝났을 때를 의미합니다. 때문에 위에 코드도 조건부 처리를 해주면서 렌더링을 하였습니다. 여기서도 시간이 많이 잡아먹었습니다.. !isLoading 조건부 처리를 해주지 않아서 계속 data undefiend가 떳거든요..

## ✍ 궁금한 것

### 1️⃣ 주간 팔로잉 현황 목록에 1명 혹은 2명일 떄 
주간 팔로잉 현황 목록에 1명이거나 2명일 때 나오는 현황 목록에 조건부 렌더링을 걸어주면 되긴 할 것 같은데, 문제는 Pie 컴포넌트가 엄청나게 늘어날 것 같아서 어떻게 해야 할지 감이 잡히질 않네요,, 

### 2️⃣ WeeklyFollower.tsx 파일에서 hasFollower
`` const hasFollowers = followings.length > 0; // ! hasFollowers 를 사용했을 떄 렌더링이 되질 않음(length undefiend)```
hasFollowers 라는 변수를 저장해서 ```!isLoading && followings.length > 0 ``` 대신에 변수를 넣어서 사용하고 싶은데 변수를 넣을 떄 length undefined 라는 오류가 계속해서 떠서 사용을 하지 못하였습니다,, 이유가 뭔지 모르겠네요

### 3️⃣ 캘린더 부분 오류 CommonCalendar 
캘린더 부분에서 NavBar를 클릭하고 '월' 을 옮겨가며 날짜가 바뀌는 것은 잘 적용됩니다. 하지만 요일수를 클릭하고, '월' 을 바꾸게 되면 안에 있는 날짜값이 '월' 에 맞게 렌더링이 되질 않습니다. 
<img width="306" alt="image" src="https://github.com/user-attachments/assets/a79fbf70-005b-4a2f-b687-5a6954ec04db">


아마 제 생각엔 onChange 부분에서 뭔가 오류가 있는것같은데 뭔지 잘 모르겠습니다..
```jsx
<StyledCalendar
        onChange={setSelectedDate}
        locale="ko"
        value={selectedDate}
        showNeighboringMonth={true}
        formatShortWeekday={(_, date) => customWeekdays[date.getDay()]}
        showNavigation={false}
        tileClassName={({ date, view }) => {
          if (view === 'month') {
            const day = date.getDate().toString();
            const month = date.getMonth() + 1;
            const year = date.getFullYear();

            // 현재 달의 날짜인지 확인
            if (month === clickedMonth && year === clickedYear) {
              const solvedDay = board.find((d) => d.date === day && d.isSolved);
              return solvedDay ? 'solved' : null;
            }
          }
          return null;
        }}
      />
      
```


