### PR TITLE
[ Profile ] api 연결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -11,6 +11,7 @@ import GroupMemberPage from './page/GroupMemberPage';
 import Home from './page/Home';
 import LoginPage from './page/LoginPage';
 import MyGroup from './page/MyGroup';
+import MyProfilePage from './page/MyProfilePage';
 import RegisterPage from './page/RegisterPage';
 import SolutionListPage from './page/SolutionListPage';
 import SolutionPage from './page/SolutionPage';
@@ -21,6 +22,7 @@ const Router = () => {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/:nickname" element={<MyProfilePage />} />
         <Route path="/group" />
         <Route path="/group/:id" element={<GroupDetail />} />
         <Route path="/group/:id/admin" element={<AdminPage />} />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -22,7 +22,7 @@ const Router = () => {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/:nickname" element={<MyProfilePage />} />
+        <Route path="/:id" element={<MyProfilePage />} />
         <Route path="/group" />
         <Route path="/group/:id" element={<GroupDetail />} />
         <Route path="/group/:id/admin" element={<AdminPage />} />

--- a/src/common/CommonInput.tsx
+++ b/src/common/CommonInput.tsx
@@ -6,6 +6,7 @@ import { CommonInputProps } from '../types/CommonInput/inputType';
 import { handleInput } from '../utils/handleInput';
 
 const CommonInput = ({
+  isClickedCheckBtn,
   category,
   value,
   isExitedNickname,
@@ -18,11 +19,15 @@ const CommonInput = ({
       category === 'secretKey') &&
       value.length > 20) ||
     (category === 'num' && parseInt(value) > 50) ||
-    (category === 'nickname' && (value.length > 10 || isExitedNickname)) ||
+    (category === 'nickname' &&
+      (value.length > 10 || (isExitedNickname && isClickedCheckBtn))) ||
     (category === 'password' && isNotMatchedPW);
 
   const isNicknameSuccess =
-    category === 'nickname' && !isExitedNickname && value.length !== 0;
+    category === 'nickname' &&
+    isClickedCheckBtn &&
+    !isExitedNickname &&
+    value.length !== 0;
 
   const [placeholder, setPlaceholder] = useState('');
 
@@ -95,7 +100,7 @@ const CommonInput = ({
         </Notice>
       )}
 
-      {(isNotMatchedPW || isExitedNickname) && (
+      {(isNotMatchedPW || (isExitedNickname && isClickedCheckBtn)) && (
         <ErrorMessage $isPW={category === 'password'}>
           {ERROR_MSG[category as keyof typeof ERROR_MSG]}
         </ErrorMessage>

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -1,11 +1,18 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcLoginIcon, IcLogo } from '../assets';
 import { DATA } from '../constants/Header/HeaderConst';
 import { HeaderProps } from '../types/Header/HeaderType';
 
 const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
+  const navigate = useNavigate();
   const nickname = sessionStorage.getItem('nickname');
   const isLogin = nickname && nickname.length > 0;
+
+  const handleClickProfile = () => {
+    navigate(`/${nickname}`);
+  };
+
   return (
     <HeaderWrapper>
       <HeaderContainer>
@@ -31,7 +38,10 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
             })}
           </NavBarUl>
         </NavBarContainer>
-        <LoginBtnContainer $isLogin={isLogin ? true : false}>
+        <LoginBtnContainer
+          $isLogin={isLogin ? true : false}
+          onClick={handleClickProfile}
+        >
           <IcLoginIcon />
           <LoginBtn>{isLogin ? `${nickname} 님` : '로그인'}</LoginBtn>
         </LoginBtnContainer>

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -7,10 +7,12 @@ import { HeaderProps } from '../types/Header/HeaderType';
 const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   const navigate = useNavigate();
   const nickname = sessionStorage.getItem('nickname');
+  const user = sessionStorage.getItem('user');
+  const userId = user && parseInt(user);
   const isLogin = nickname && nickname.length > 0;
 
   const handleClickProfile = () => {
-    navigate(`/${nickname}`);
+    navigate(`/${userId}`);
   };
 
   return (

--- a/src/components/MyProfile/FollowingList.tsx
+++ b/src/components/MyProfile/FollowingList.tsx
@@ -156,7 +156,6 @@ const RecommendCard = styled.article`
   display: grid;
   gap: 0.4rem 1.8rem;
   grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: repeat(4, 1fr);
 
   width: 100%;
   padding: 2rem;

--- a/src/components/MyProfile/FollowingList.tsx
+++ b/src/components/MyProfile/FollowingList.tsx
@@ -6,6 +6,7 @@ import {
   IcUnfollowingWhite,
 } from '../../assets';
 import useUpdateFollower from '../../libs/hooks/Follower/useUpdateFollower';
+import useDeleteUser from '../../libs/hooks/MyProfile/useDeleteUser';
 import useGetFollowList from '../../libs/hooks/MyProfile/useGetFollowList';
 import { UpdateFollowerProps } from '../../types/Follower/Personal/personalType';
 import { UserType } from '../../types/MyProfile/MyProfileType';
@@ -14,6 +15,7 @@ const FollowingList = () => {
   const [isFollowerSelected, setIsFollowerSelected] = useState(true);
 
   const { mutation } = useUpdateFollower();
+  const { deleteMutation } = useDeleteUser();
   const { followData, isLoading } = useGetFollowList(isFollowerSelected);
   const { users, count } = !isLoading && followData.data;
 
@@ -25,7 +27,12 @@ const FollowingList = () => {
   };
 
   const handleDeleteAccount = () => {
-    /* 회원탈퇴 */
+    if (
+      window.confirm(
+        '지금 탈퇴하시면 더 이상 서비스를 이용할 수 없습니다. 탈퇴하시겠습니까?'
+      )
+    )
+      deleteMutation();
   };
 
   return (

--- a/src/components/MyProfile/FollowingList.tsx
+++ b/src/components/MyProfile/FollowingList.tsx
@@ -6,59 +6,16 @@ import {
   IcUnfollowingWhite,
 } from '../../assets';
 import useUpdateFollower from '../../libs/hooks/Follower/useUpdateFollower';
+import useGetFollowList from '../../libs/hooks/MyProfile/useGetFollowList';
 import { UpdateFollowerProps } from '../../types/Follower/Personal/personalType';
+import { UserType } from '../../types/MyProfile/MyProfileType';
 
 const FollowingList = () => {
-  // 더미 데이터 생성
-  const followerData = [
-    {
-      userId: 1,
-      profileImg: '',
-      nickname: '일이삼사오육칠팔구십',
-      language: 'JavaScript',
-      githubUrl: '',
-      isFollowing: true,
-    },
-    {
-      userId: 2,
-      profileImg: '',
-      nickname: '팔로워유저1',
-      language: 'Python',
-      githubUrl: '',
-      isFollowing: true,
-    },
-    {
-      userId: 3,
-      profileImg: '',
-      nickname: '팔로워유저2',
-      language: 'Java',
-      githubUrl: '',
-      isFollowing: true,
-    },
-  ];
-
-  const followingData = [
-    {
-      userId: 4,
-      profileImg: '',
-      nickname: '팔로잉유저1',
-      language: 'C++',
-      githubUrl: '',
-      isFollowing: true,
-    },
-    {
-      userId: 5,
-      profileImg: '',
-      nickname: '팔로잉유저2',
-      language: 'TypeScript',
-      githubUrl: '',
-      isFollowing: true,
-    },
-  ];
-
   const [isFollowerSelected, setIsFollowerSelected] = useState(true);
 
   const { mutation } = useUpdateFollower();
+  const { followData, isLoading } = useGetFollowList(isFollowerSelected);
+  const { users, count } = !isLoading && followData.data;
 
   const handleClickFollowerBtn = ({
     nickname,
@@ -76,9 +33,7 @@ const FollowingList = () => {
       <HeaderContainer>
         <TitleContainer>
           <Title>친구 목록</Title>
-          <FriendCount>
-            {isFollowerSelected ? followerData.length : followingData.length}명
-          </FriendCount>
+          <FriendCount>{count}명</FriendCount>
         </TitleContainer>
         <TabContainer>
           <Tab
@@ -97,18 +52,8 @@ const FollowingList = () => {
         </TabContainer>
       </HeaderContainer>
       <RecommendCard>
-        {(isFollowerSelected ? followerData : followingData).map(
-          (
-            user: {
-              userId: number;
-              profileImg: string;
-              nickname: string;
-              language: string;
-              githubUrl: string;
-              isFollowing: boolean;
-            },
-            idx: number
-          ) => {
+        {!isLoading &&
+          users.map((user: UserType, idx: number) => {
             const {
               userId,
               profileImg,
@@ -151,8 +96,7 @@ const FollowingList = () => {
                 </FollowingBtn>
               </PersonalCard>
             );
-          }
-        )}
+          })}
       </RecommendCard>
       <DeleteIdContainer>
         <DeleteText>코드라이브를 더이상 이용하지 않는다면</DeleteText>

--- a/src/components/MyProfile/MyGoal.tsx
+++ b/src/components/MyProfile/MyGoal.tsx
@@ -4,6 +4,7 @@ import { IcAdd, IcMinusWhite } from '../../assets';
 import usePatchGoal from '../../libs/hooks/MyProfile/usePatchGoal';
 
 const MyGoal = () => {
+  // 추후 서버에서 받아온 목표 값으로 초기화해주세요
   const [number, setNumber] = useState(0);
   const [isSaved, setIsSaved] = useState(false);
 

--- a/src/components/MyProfile/MyGoal.tsx
+++ b/src/components/MyProfile/MyGoal.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { IcAdd, IcMinusWhite } from '../../assets';
+import usePatchGoal from '../../libs/hooks/MyProfile/usePatchGoal';
 
 const MyGoal = () => {
   const [number, setNumber] = useState(0);
   const [isSaved, setIsSaved] = useState(false);
 
+  const { mutation } = usePatchGoal(() => setIsSaved(true));
+
   const handleSaveBtnClick = () => {
-    setIsSaved(true);
+    mutation(number);
   };
 
   const handleCancelBtnClick = () => {

--- a/src/components/MyProfile/Profile.tsx
+++ b/src/components/MyProfile/Profile.tsx
@@ -1,19 +1,15 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { IcGithub, IcRevise } from '../../assets';
+import useGetUser from '../../libs/hooks/MyProfile/useGetUser';
 import { handleClickLink } from '../../utils/handleClickLink';
 import ProfileEdilt from './ProfileEdit';
 
 const Profile = () => {
   const [modalOn, setModalOn] = useState(false);
-  const info = {
-    profileImg: '',
-    language: 'Javascript',
-    githubUrl: '',
-    nickname: '매링구',
-    comment: '안녕하세요 풀스택 개발자 코딩하는 갱얼쥐입니다',
-  };
-  const { profileImg, language, githubUrl, nickname, comment } = info;
+  const { data, isLoading } = useGetUser();
+  const { comment, githubUrl, language, nickname, profileImg } =
+    !isLoading && data?.data;
 
   // 모달 열기 함수
   const handleOpenModal = () => {

--- a/src/components/MyProfile/Profile.tsx
+++ b/src/components/MyProfile/Profile.tsx
@@ -50,7 +50,10 @@ const Profile = () => {
       {modalOn && ( // 모달이 열려 있을 때만 ProfileEdilt 렌더링
         <ModalBackground onClick={handleCloseModal}>
           <ModalContent onClick={(e) => e.stopPropagation()}>
-            <ProfileEdilt handleCloseModal={handleCloseModal} />
+            <ProfileEdilt
+              handleCloseModal={handleCloseModal}
+              initialData={!isLoading && data?.data}
+            />
           </ModalContent>
         </ModalBackground>
       )}

--- a/src/components/MyProfile/ProfileEdit.tsx
+++ b/src/components/MyProfile/ProfileEdit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import CommonButton from '../../common/CommonButton';
 import { ProfileEdiltProps } from '../../types/MyProfile/MyProfileType';
@@ -9,39 +9,21 @@ import LanguageInfo from '../Profile/LanguageInfo';
 import NameInfo from '../Profile/NameInfo';
 import NicknameInfo from '../Profile/NicknameInfo';
 
-const ProfileEdilt = ({ handleCloseModal }: ProfileEdiltProps) => {
-  /* 기존 값들을 더미로 넣어둠 api 연결하면서 삭제 할 예정 */
-  const initialData = {
-    nickname: 'moonju',
-    github: 'example',
-    intro: '코테에 목숨을 걸었습니다!',
-    language: 'JavaScript',
-  };
-
-  const user = '김문주';
-
+const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
   const [inputs, setInputs] = useState(initialData);
   const [selectedLanguage, setSelectedLanguage] = useState(
     initialData.language
   );
-  const [initialInputs] = useState(initialData);
-
-  const { nickname, github, intro } = inputs;
+  const [isExitNickname, setIsExitNickname] = useState(false);
+  const { comment, githubUrl, language, nickname } = inputs;
 
   // 입력 값의 유효성을 검사하는 변수
   const isActive =
     nickname.length > 0 &&
     nickname.length <= 10 &&
-    intro.length > 0 &&
-    intro.length <= 30 &&
-    github.length > 0 &&
+    comment?.length <= 30 &&
+    githubUrl.length > 0 &&
     selectedLanguage.length > 0;
-
-  useEffect(() => {
-    // 컴포넌트가 마운트되면 초기 상태를 설정합니다.
-    setInputs(initialData);
-    setSelectedLanguage(initialData.language);
-  }, []);
 
   // 입력 값 변경 처리 함수
   const handleChangeInputs = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -58,10 +40,10 @@ const ProfileEdilt = ({ handleCloseModal }: ProfileEdiltProps) => {
   };
 
   // 소개글 변경 처리 함수
-  const handleChangeIntro = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChangeComment = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = e.target;
-    handleInput(e, 'intro');
-    setInputs((prev) => ({ ...prev, intro: value }));
+    handleInput(e, 'comment');
+    setInputs((prev) => ({ ...prev, comment: value }));
   };
 
   // 가입 버튼 클릭 처리 함수
@@ -73,13 +55,13 @@ const ProfileEdilt = ({ handleCloseModal }: ProfileEdiltProps) => {
   // 취소 버튼 클릭 처리 함수
   const handleCancelBtnClick = () => {
     // 입력 값들을 초기 상태로 되돌림
-    setInputs(initialInputs);
-    setSelectedLanguage(initialData.language);
+    setInputs(initialData);
+    setSelectedLanguage(language);
     handleCloseModal(); // 모달 닫기
   };
 
-  // 닉네임 중복 체크 함수 (구현 필요)
-  const handleNicknameCheck = async () => {
+  // 닉네임 중복 체크 함수
+  const handleNicknameCheck = () => {
     // 닉네임 중복 체크 로직 추가
   };
 
@@ -88,12 +70,18 @@ const ProfileEdilt = ({ handleCloseModal }: ProfileEdiltProps) => {
       <ProfileContainer onSubmit={handleSaveBtnClick}>
         <BasicInfoContainer>
           <BasicTitle>기본정보</BasicTitle>
-          <NameInfo user={user} />
-          <GithubInfo github={github} handleChangeInputs={handleChangeInputs} />
+          <NameInfo user={nickname} />
+          <GithubInfo
+            github={githubUrl}
+            handleChangeInputs={handleChangeInputs}
+          />
         </BasicInfoContainer>
         <CodriveContainer>
           <CodriveTitle>코드라이브 정보</CodriveTitle>
-          <IntroInfo value={intro} onChange={handleChangeIntro} />
+          <IntroInfo
+            value={comment ? comment : ''}
+            onChange={handleChangeComment}
+          />
           <NicknameInfo
             nickname={nickname}
             handleChangeInputs={handleChangeInputs}

--- a/src/components/MyProfile/ProfileEdit.tsx
+++ b/src/components/MyProfile/ProfileEdit.tsx
@@ -24,6 +24,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
 
   const { originNickname, isExitNickname, isClickedCheckBtn } = changeNickname;
   const { comment, githubUrl, language, nickname, name } = inputs;
+  const githubNickname = githubUrl.split('/')[githubUrl.split('/').length - 1];
 
   const { patchMutation } = usePatchUser(nickname);
   const { mutation } = usePostCheckExitNickname((isExit: boolean) =>
@@ -96,7 +97,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
           <BasicTitle>기본정보</BasicTitle>
           <NameInfo user={name} />
           <GithubInfo
-            github={githubUrl}
+            github={githubNickname}
             handleChangeInputs={handleChangeInputs}
           />
         </BasicInfoContainer>

--- a/src/components/MyProfile/ProfileEdit.tsx
+++ b/src/components/MyProfile/ProfileEdit.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import CommonButton from '../../common/CommonButton';
+import usePostCheckExitNickname from '../../libs/hooks/MyProfile/usePostCheckExitNickname';
 import { ProfileEdiltProps } from '../../types/MyProfile/MyProfileType';
 import { handleInput } from '../../utils/handleInput';
 import GithubInfo from '../Profile/GIthubInfo';
@@ -14,7 +15,13 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
   const [selectedLanguage, setSelectedLanguage] = useState(
     initialData.language
   );
-  const [isExitNickname, setIsExitNickname] = useState(false);
+  const [changeNickname, setChangeNickname] = useState({
+    isExitNickname: false,
+    isClickedCheckBtn: false,
+  });
+  const { mutation } = usePostCheckExitNickname((isExit: boolean) =>
+    setChangeNickname({ isExitNickname: isExit, isClickedCheckBtn: true })
+  );
   const { comment, githubUrl, language, nickname } = inputs;
 
   // 입력 값의 유효성을 검사하는 변수
@@ -32,6 +39,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
       ...prev,
       [name]: value,
     }));
+    setChangeNickname({ ...changeNickname, isClickedCheckBtn: false });
   };
 
   // 언어 태그 변경 처리 함수
@@ -62,7 +70,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
 
   // 닉네임 중복 체크 함수
   const handleNicknameCheck = () => {
-    // 닉네임 중복 체크 로직 추가
+    mutation(nickname);
   };
 
   return (
@@ -83,6 +91,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
             onChange={handleChangeComment}
           />
           <NicknameInfo
+            changeNickname={changeNickname}
             nickname={nickname}
             handleChangeInputs={handleChangeInputs}
             handleNicknameCheck={handleNicknameCheck}

--- a/src/components/MyProfile/ProfileEdit.tsx
+++ b/src/components/MyProfile/ProfileEdit.tsx
@@ -17,21 +17,35 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
     initialData.language
   );
   const [changeNickname, setChangeNickname] = useState({
+    originNickname: initialData.nickname,
     isExitNickname: false,
     isClickedCheckBtn: false,
   });
-  const { patchMutation } = usePatchUser();
+
+  const { originNickname, isExitNickname, isClickedCheckBtn } = changeNickname;
+  const { comment, githubUrl, language, nickname, name } = inputs;
+
+  const { patchMutation } = usePatchUser(nickname);
   const { mutation } = usePostCheckExitNickname((isExit: boolean) =>
-    setChangeNickname({ isExitNickname: isExit, isClickedCheckBtn: true })
+    setChangeNickname({
+      ...changeNickname,
+      isExitNickname: isExit,
+      isClickedCheckBtn: true,
+    })
   );
-  const { comment, githubUrl, language, nickname } = inputs;
 
   // 입력 값의 유효성을 검사하는 변수
   const isActive =
-    nickname.length > 0 &&
-    nickname.length <= 10 &&
-    githubUrl.length > 0 &&
-    selectedLanguage.length > 0;
+    ((originNickname !== nickname &&
+      isClickedCheckBtn &&
+      !isExitNickname &&
+      nickname.length > 0 &&
+      nickname.length <= 10) ||
+      originNickname === nickname) &&
+    ((language !== selectedLanguage && selectedLanguage.length > 0) ||
+      language === selectedLanguage) &&
+    (!comment || (comment.length > 0 && comment.length <= 30)) &&
+    (!githubUrl || githubUrl.length > 0);
 
   // 입력 값 변경 처리 함수
   const handleChangeInputs = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -58,7 +72,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
   // 가입 버튼 클릭 처리 함수
   const handleSaveBtnClick = () => {
     if (!isActive) return;
-    patchMutation({comment, githubUrl, language, nickname})
+    patchMutation({ comment, githubUrl, language: selectedLanguage, nickname });
     handleCloseModal(); // 모달 닫기
   };
 
@@ -80,7 +94,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
       <ProfileContainer onSubmit={handleSaveBtnClick}>
         <BasicInfoContainer>
           <BasicTitle>기본정보</BasicTitle>
-          <NameInfo user={nickname} />
+          <NameInfo user={name} />
           <GithubInfo
             github={githubUrl}
             handleChangeInputs={handleChangeInputs}

--- a/src/components/MyProfile/ProfileEdit.tsx
+++ b/src/components/MyProfile/ProfileEdit.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import CommonButton from '../../common/CommonButton';
+import usePatchUser from '../../libs/hooks/MyProfile/usePatchUser';
 import usePostCheckExitNickname from '../../libs/hooks/MyProfile/usePostCheckExitNickname';
 import { ProfileEdiltProps } from '../../types/MyProfile/MyProfileType';
 import { handleInput } from '../../utils/handleInput';
@@ -19,6 +20,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
     isExitNickname: false,
     isClickedCheckBtn: false,
   });
+  const { patchMutation } = usePatchUser();
   const { mutation } = usePostCheckExitNickname((isExit: boolean) =>
     setChangeNickname({ isExitNickname: isExit, isClickedCheckBtn: true })
   );
@@ -28,7 +30,6 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
   const isActive =
     nickname.length > 0 &&
     nickname.length <= 10 &&
-    comment?.length <= 30 &&
     githubUrl.length > 0 &&
     selectedLanguage.length > 0;
 
@@ -57,6 +58,7 @@ const ProfileEdilt = ({ handleCloseModal, initialData }: ProfileEdiltProps) => {
   // 가입 버튼 클릭 처리 함수
   const handleSaveBtnClick = () => {
     if (!isActive) return;
+    patchMutation({comment, githubUrl, language, nickname})
     handleCloseModal(); // 모달 닫기
   };
 

--- a/src/components/Profile/NicknameInfo.tsx
+++ b/src/components/Profile/NicknameInfo.tsx
@@ -4,10 +4,11 @@ import CommonInput from './../../common/CommonInput';
 
 const NicknameInfo = ({
   nickname,
-
+  changeNickname,
   handleChangeInputs,
   handleNicknameCheck,
 }: NickNameInfoProps) => {
+  const {isExitNickname, isClickedCheckBtn} = changeNickname;
   return (
     <NicknameInfoContainer>
       <NicknameTitle>닉네임</NicknameTitle>
@@ -15,6 +16,8 @@ const NicknameInfo = ({
         <CommonInput
           category="nickname"
           value={nickname}
+          isClickedCheckBtn={isClickedCheckBtn}
+          isExitedNickname={isExitNickname}
           handleChangeInputs={handleChangeInputs}
         />
         <Button type="button" onClick={handleNicknameCheck}>

--- a/src/libs/apis/MyProfile/deleteUser.ts
+++ b/src/libs/apis/MyProfile/deleteUser.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+const deleteUser = async () => {
+  const user = sessionStorage.getItem('user');
+  const userId = user && parseInt(user);
+  const { data } = await api.delete(`/users/${userId}/withdraw`);
+
+  return data;
+};
+
+export default deleteUser;

--- a/src/libs/apis/MyProfile/getFollowList.ts
+++ b/src/libs/apis/MyProfile/getFollowList.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+const getFollowList = async (isFollowerSelected: boolean) => {
+  const { data } = await api.get(
+    `/users/${isFollowerSelected ? 'followers' : 'followings'}`
+  );
+
+  return data;
+};
+
+export default getFollowList;

--- a/src/libs/apis/MyProfile/getUser.ts
+++ b/src/libs/apis/MyProfile/getUser.ts
@@ -1,0 +1,12 @@
+import { api } from '../../api';
+
+const getUser = async () => {
+  const user = sessionStorage.getItem('user');
+  const userId = user && parseInt(user);
+
+  const { data } = await api.get(`/users/${userId}`);
+
+  return data;
+};
+
+export default getUser;

--- a/src/libs/apis/MyProfile/patchGoal.ts
+++ b/src/libs/apis/MyProfile/patchGoal.ts
@@ -1,0 +1,13 @@
+import { api } from '../../api';
+
+const patchGoal = async (goal: number) => {
+  const user = sessionStorage.getItem('user');
+  const userId = user && parseInt(user);
+  const { data } = await api.patch(`/users/${userId}/goal`, {
+    goal: goal,
+  });
+
+  return data;
+};
+
+export default patchGoal;

--- a/src/libs/apis/MyProfile/patchUser.ts
+++ b/src/libs/apis/MyProfile/patchUser.ts
@@ -1,0 +1,22 @@
+import { PatchUserProps } from '../../../types/MyProfile/MyProfileType';
+import { api } from '../../api';
+
+const patchUser = async ({
+  nickname,
+  githubUrl,
+  comment,
+  language,
+}: PatchUserProps) => {
+  const id = sessionStorage.getItem('user');
+  const userId = id && parseInt(id);
+  const { data } = await api.patch(`/users/${userId}/profile`, {
+    nickname: nickname,
+    githubUrl: githubUrl,
+    comment: comment,
+    language: language,
+  });
+
+  return data;
+};
+
+export default patchUser;

--- a/src/libs/apis/MyProfile/postCheckExitNickname.ts
+++ b/src/libs/apis/MyProfile/postCheckExitNickname.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+const postCheckExitNickname = async (nickname: string) => {
+  const { data } = await api.post('/users/nickname', {
+    nickname: nickname ? nickname : sessionStorage.getItem('nickname'),
+  });
+
+  return data;
+};
+
+export default postCheckExitNickname;

--- a/src/libs/hooks/Follower/useUpdateFollower.ts
+++ b/src/libs/hooks/Follower/useUpdateFollower.ts
@@ -10,6 +10,7 @@ const useUpdateFollower = () => {
       await updateFollower({ nickname, isDelete }),
     onError: (err) => console.log(err.message),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-follow-list'] });
       queryClient.invalidateQueries({ queryKey: ['get-follower-summary'] });
       queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
       queryClient.invalidateQueries({ queryKey: ['get-follower-recommend'] });

--- a/src/libs/hooks/MyProfile/useDeleteUser.ts
+++ b/src/libs/hooks/MyProfile/useDeleteUser.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import deleteUser from '../../apis/MyProfile/deleteUser';
+
+const useDeleteUser = () => {
+  const navigate = useNavigate();
+
+  const mutation = useMutation({
+    mutationFn: async () => await deleteUser(),
+    onSuccess: () => {
+      navigate('/login');
+      sessionStorage.clear();
+    },
+  });
+
+  return { deleteMutation: mutation.mutate };
+};
+
+export default useDeleteUser;

--- a/src/libs/hooks/MyProfile/useGetFollowList.ts
+++ b/src/libs/hooks/MyProfile/useGetFollowList.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import getFollowList from '../../apis/MyProfile/getFollowList';
+
+const useGetFollowList = (isFollowerSelected: boolean) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['get-follow-list', isFollowerSelected],
+    queryFn: async () => await getFollowList(isFollowerSelected),
+  });
+
+  return { followData: data, isLoading };
+};
+
+export default useGetFollowList;

--- a/src/libs/hooks/MyProfile/useGetUser.ts
+++ b/src/libs/hooks/MyProfile/useGetUser.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import getUser from '../../apis/MyProfile/getUser';
+
+const useGetUser = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['get-user'],
+    queryFn: async () => await getUser(),
+  });
+
+  return { data, isLoading };
+};
+
+export default useGetUser;

--- a/src/libs/hooks/MyProfile/usePatchGoal.ts
+++ b/src/libs/hooks/MyProfile/usePatchGoal.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import patchGoal from '../../apis/MyProfile/patchGoal';
+
+const usePatchGoal = (saveGoal: () => void) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (goal: number) => await patchGoal(goal),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-goal'] });
+      saveGoal();
+    },
+  });
+
+  return { mutation: mutation.mutate };
+};
+
+export default usePatchGoal;

--- a/src/libs/hooks/MyProfile/usePatchUser.ts
+++ b/src/libs/hooks/MyProfile/usePatchUser.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PatchUserProps } from '../../../types/MyProfile/MyProfileType';
+import patchUser from '../../apis/MyProfile/patchUser';
+
+const usePatchUser = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async ({
+      nickname,
+      githubUrl,
+      comment,
+      language,
+    }: PatchUserProps) =>
+      await patchUser({ nickname, githubUrl, comment, language }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-user'] }),
+        queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
+    },
+  });
+
+  return { patchMutation: mutation.mutate };
+};
+
+export default usePatchUser;

--- a/src/libs/hooks/MyProfile/usePatchUser.ts
+++ b/src/libs/hooks/MyProfile/usePatchUser.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PatchUserProps } from '../../../types/MyProfile/MyProfileType';
 import patchUser from '../../apis/MyProfile/patchUser';
 
-const usePatchUser = () => {
+const usePatchUser = (nickname: string) => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: async ({
@@ -13,8 +13,13 @@ const usePatchUser = () => {
     }: PatchUserProps) =>
       await patchUser({ nickname, githubUrl, comment, language }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['get-user'] }),
-        queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
+      const originNickname = sessionStorage.getItem('nickname');
+      queryClient.invalidateQueries({ queryKey: ['get-user'] });
+      queryClient.invalidateQueries({ queryKey: ['get-user-profile'] });
+      if (originNickname !== nickname) {
+        sessionStorage.setItem('nickname', nickname);
+        window.location.reload();
+      }
     },
   });
 

--- a/src/libs/hooks/MyProfile/usePostCheckExitNickname.ts
+++ b/src/libs/hooks/MyProfile/usePostCheckExitNickname.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import postCheckExitNickname from '../../apis/MyProfile/postCheckExitNickname';
+
+const usePostCheckExitNickname = (
+  updateIsExitNickname: (isExit: boolean) => void
+) => {
+  const mutation = useMutation({
+    mutationFn: async (nickname: string) =>
+      await postCheckExitNickname(nickname),
+    onSuccess: () => {
+      updateIsExitNickname(false);
+    },
+    onError: (err: { response: { data: { code: number } } }) => {
+      const { code } = err.response.data;
+      if (code === 409) updateIsExitNickname(true);
+    },
+  });
+
+  return { mutation: mutation.mutate };
+};
+
+export default usePostCheckExitNickname;

--- a/src/types/CommonInput/inputType.ts
+++ b/src/types/CommonInput/inputType.ts
@@ -1,6 +1,7 @@
 export interface CommonInputProps {
   category: string;
   value: string;
+  isClickedCheckBtn?: boolean;
   isExitedNickname?: boolean;
   isNotMatchedPW?: boolean;
   handleChangeInputs: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/types/MyProfile/MyProfileType.tsx
+++ b/src/types/MyProfile/MyProfileType.tsx
@@ -1,3 +1,9 @@
 export interface ProfileEdiltProps {
   handleCloseModal: () => void;
+  initialData: {
+    comment: string;
+    githubUrl: string;
+    language: string;
+    nickname: string;
+  };
 }

--- a/src/types/MyProfile/MyProfileType.tsx
+++ b/src/types/MyProfile/MyProfileType.tsx
@@ -12,5 +12,6 @@ export interface ProfileEdiltProps {
     githubUrl: string;
     language: string;
     nickname: string;
+    name: string;
   };
 }

--- a/src/types/MyProfile/MyProfileType.tsx
+++ b/src/types/MyProfile/MyProfileType.tsx
@@ -15,3 +15,12 @@ export interface ProfileEdiltProps {
     name: string;
   };
 }
+
+export interface UserType {
+  userId: number;
+  profileImg: string;
+  nickname: string;
+  language: string;
+  githubUrl: string;
+  isFollowing: boolean;
+}

--- a/src/types/MyProfile/MyProfileType.tsx
+++ b/src/types/MyProfile/MyProfileType.tsx
@@ -1,3 +1,10 @@
+export interface PatchUserProps {
+  nickname: string;
+  language: string;
+  comment: string;
+  githubUrl: string;
+}
+
 export interface ProfileEdiltProps {
   handleCloseModal: () => void;
   initialData: {

--- a/src/types/Profile/ProfileType.tsx
+++ b/src/types/Profile/ProfileType.tsx
@@ -16,7 +16,7 @@ export interface LanguageInfoProps {
 
 export interface NickNameInfoProps {
   nickname: string;
-
+  changeNickname: {isExitNickname: boolean, isClickedCheckBtn: boolean};
   handleChangeInputs: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleNicknameCheck: () => void;
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #186 

## ✅ 작업 내용

- [x] 닉네임 중복 체크 api 연결
- [x] 사용자 정보 패치 api 연결
- [x] 사용자 정보 불러오는 api 연결
- [x] 목표 저장 api 연결
- [x] 사용자 탈퇴 api 연결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/78fdb201-ca56-47ac-ae4a-2338f5a1241c


<br />

## 📌 이슈 사항
### 1️⃣ 각종 api 및 로직 연결
- 위에 체크해둔 api 연결했습니다.
- 내 프로필 뷰로 넘어오려면 헤더에 있는 프로필을 클릭하면 됩니다.

### 2️⃣ 사용자 정보 변경 모달이 active 되는 조건
- 기존 조건대로라면 닉네임을 변경 후 중복검사를 하지 않아도 잘 저장이 되고, 옵션으로 설정된 한 줄 소개나 깃허브 링크가 저장되지 않는다면 에러를 뱉는 등 여러 문제가 있었어요.
이걸 해결하기 위해서 조건들을 변경해줬고, 지금도 완벽하진 않지만 이전보단 올바른 로직으로 동작하고 있습니다. 
(이 부분은 담당자인 문주언니가 더 보충해주면 좋을 것 같아요)
```typescript
  const isActive =
    ((originNickname !== nickname &&
      isClickedCheckBtn &&
      !isExitNickname &&
      nickname.length > 0 &&
      nickname.length <= 10) ||
      originNickname === nickname) &&
    ((language !== selectedLanguage && selectedLanguage.length > 0) ||
      language === selectedLanguage) &&
    (!comment || (comment.length > 0 && comment.length <= 30)) &&
    (!githubUrl || githubUrl.length > 0);
```

<br />

## ✍ 전달사항 (To. 문주언니)
### 1️⃣ 프로필 수정 모달)) 뒷 배경 클릭해도 onClick 함수 먹히지 않음
- e.stopPropagation이 원인임을 파악
- 그러나 여러 로직이 엮여있어 이 코드를 지우면 다른 코드에도 영향이 감 -> 따로 수정하지 않음

### 2️⃣ 프로필 수정 모달))  깃허브 주소 변경하는 부분 인풋 수정이 안됨

### 4️⃣ 프로필 수정 모달)) 언어 선택 부분 밑으로 쭉 내리면 UI가 뭔가.. 이상함 
- 원래 이 의도인지? 모르겠음 유진이한테 물어봐주세여

https://github.com/user-attachments/assets/32e86ab0-9399-4ac1-82f8-6a91b2318ce0


### 5️⃣ 친구 목록쪽에서 프로필 수정 모달 띄우면 UI 깨짐 (친구목록이 모달 위로 올라옴)
<img width="715" alt="스크린샷 2024-09-04 오후 6 16 29" src="https://github.com/user-attachments/assets/1618d2ca-17d5-41ba-981d-c9364df34adc">
