### PR TITLE
[ Follower ] 개인뷰 그래프 구현

### DIFF
--- a/src/common/CommonMonthSolve.tsx
+++ b/src/common/CommonMonthSolve.tsx
@@ -3,7 +3,11 @@ import styled from 'styled-components';
 import CommonCalendar from '../components/Calendar/Calendar';
 import useGetMonthSolve from '../libs/hooks/Home/useGetMonthSolve';
 
-const CommonMonthSolve = () => {
+interface CommonMonthSolveProps {
+  userId: number;
+}
+
+const CommonMonthSolve = ({ userId }: CommonMonthSolveProps) => {
   const currentMonth = new Date().getMonth() + 1; // getMonth()는 0부터 시작하므로 +1 필요
   const monthText = `${currentMonth}월 문제풀이 현황`;
 
@@ -12,6 +16,7 @@ const CommonMonthSolve = () => {
   const [clickedMonth, setClickedMonth] = useState(currentMonth);
 
   const { data, isLoading } = useGetMonthSolve({
+    userId: userId,
     year: clickedYear,
     month: clickedMonth,
   });

--- a/src/components/Follower/FollowerInfo.tsx
+++ b/src/components/Follower/FollowerInfo.tsx
@@ -7,6 +7,7 @@ import {
 import useUpdateFollower from '../../libs/hooks/Follower/useUpdateFollower';
 import { FollowerInfoProps } from '../../types/Follower/Personal/personalType';
 import { handleClickLink } from '../../utils/handleClickLink';
+import SuccessRate from './Personal/Graph/SuccessRate';
 
 const FollowerInfo = ({ info }: FollowerInfoProps) => {
   const {
@@ -16,7 +17,7 @@ const FollowerInfo = ({ info }: FollowerInfoProps) => {
     comment,
     language,
     githubUrl,
-    // successRate,
+    successRate,
   } = info;
 
   const { mutation } = useUpdateFollower();
@@ -30,8 +31,7 @@ const FollowerInfo = ({ info }: FollowerInfoProps) => {
       <Language>{language}</Language>
 
       <ProfileContainer>
-        <ProfileImg src={profileImg}></ProfileImg>
-
+        <SuccessRate successRate={successRate} profileImg={profileImg} />
         <ProfileTextContainer>
           <NicknameContainer>
             <Nickname>{nickname}</Nickname>
@@ -89,19 +89,10 @@ const Language = styled.p`
 
 const ProfileContainer = styled.div`
   display: flex;
+  gap: 3rem;
   justify-content: center;
   align-items: center;
   flex-direction: column;
-
-  margin: 3rem 0;
-`;
-
-const ProfileImg = styled.img`
-  width: 11rem;
-  height: 11rem;
-  margin-bottom: 3rem;
-
-  border-radius: 5rem;
 `;
 
 const ProfileTextContainer = styled.div`
@@ -166,4 +157,3 @@ const Text = styled.p<{ $isFollowed: boolean }>`
     $isFollowed ? theme.colors.gray100 : theme.colors.white};
   ${({ theme }) => theme.fonts.title_bold_16};
 `;
-

--- a/src/components/Follower/FollowerInfo.tsx
+++ b/src/components/Follower/FollowerInfo.tsx
@@ -97,7 +97,7 @@ const ProfileContainer = styled.div`
 
 const ProfileTextContainer = styled.div`
   display: flex;
-  gap: 1.8rem;
+  gap: 2rem;
   justify-content: center;
   align-items: center;
   flex-direction: column;

--- a/src/components/Follower/Personal/Graph/CustomLabel.tsx
+++ b/src/components/Follower/Personal/Graph/CustomLabel.tsx
@@ -1,0 +1,16 @@
+import { CustomLabelProps } from '../../../../types/Week/HomeFollowerTypes';
+
+const CustomLabel = ({ profileImg }: CustomLabelProps) => {
+  return (
+    <image
+      href={profileImg}
+      x={22}
+      y={22}
+      width={110}
+      height={110}
+      clipPath="circle(50%)"
+    />
+  );
+};
+
+export default CustomLabel;

--- a/src/components/Follower/Personal/Graph/SuccessRate.tsx
+++ b/src/components/Follower/Personal/Graph/SuccessRate.tsx
@@ -1,0 +1,51 @@
+import { Cell, Label, Pie, PieChart } from 'recharts';
+import { GRAPH_COLORS } from '../../../../constants/Follower/currentConst';
+import CustomLabel from './CustomLabel';
+
+interface SuccessRateProps {
+  profileImg: string;
+  successRate: number;
+}
+
+const SuccessRate = ({ profileImg, successRate }: SuccessRateProps) => {
+  const chartData = [
+    { name: 'success', value: successRate === 0 ? 10 : successRate },
+  ];
+
+  const endAngle = 90 - (360 * chartData[0].value) / 100;
+
+  return (
+    <PieChart width={154} height={154}>
+      <Pie
+        data={chartData}
+        dataKey="value"
+        stroke="none"
+        startAngle={90}
+        endAngle={-270}
+        cornerRadius={15}
+        innerRadius={68}
+        outerRadius={77}
+        fill={GRAPH_COLORS[1]}
+      >
+        <Label
+          content={<CustomLabel profileImg={profileImg} />}
+          position="center"
+        />
+      </Pie>
+      <Pie
+        data={chartData}
+        dataKey="value"
+        stroke="none"
+        startAngle={90}
+        endAngle={endAngle}
+        cornerRadius={15}
+        innerRadius={68}
+        outerRadius={77}
+      >
+        <Cell key="success" fill={GRAPH_COLORS[0]} />
+      </Pie>
+    </PieChart>
+  );
+};
+
+export default SuccessRate;

--- a/src/components/Follower/Personal/Graph/SuccessRate.tsx
+++ b/src/components/Follower/Personal/Graph/SuccessRate.tsx
@@ -17,6 +17,7 @@ const SuccessRate = ({ profileImg, successRate }: SuccessRateProps) => {
   return (
     <PieChart width={154} height={154}>
       <Pie
+        isAnimationActive={false}
         data={chartData}
         dataKey="value"
         stroke="none"
@@ -33,6 +34,7 @@ const SuccessRate = ({ profileImg, successRate }: SuccessRateProps) => {
         />
       </Pie>
       <Pie
+        isAnimationActive={false}
         data={chartData}
         dataKey="value"
         stroke="none"

--- a/src/libs/apis/Home/getMonthSolve.ts
+++ b/src/libs/apis/Home/getMonthSolve.ts
@@ -1,8 +1,7 @@
 import { getMonthSolveProps } from '../../../types/Home/getMonthSolveTypes';
 import { api } from '../../api';
 
-const getMonthSolve = async ({ year, month }: getMonthSolveProps) => {
-  const userId = sessionStorage.getItem('user');
+const getMonthSolve = async ({ year, month, userId }: getMonthSolveProps) => {
   const formatMonth = month < 10 ? `0${month}` : `${month}`;
   const { data } = await api.get(
     `/records/${userId}/board?pivotDate=${year}-${formatMonth}-01`

--- a/src/libs/hooks/Home/useGetMonthSolve.ts
+++ b/src/libs/hooks/Home/useGetMonthSolve.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { getMonthSolveProps } from '../../../types/Home/getMonthSolveTypes';
 import getMonthSolve from '../../apis/Home/getMonthSolve';
 
-const useGetMonthSolve = ({ year, month }: getMonthSolveProps) => {
+const useGetMonthSolve = ({ year, month, userId }: getMonthSolveProps) => {
   const data = useQuery({
-    queryKey: ['get-month-solve', year, month],
-    queryFn: async () => await getMonthSolve({ year, month }),
+    queryKey: ['get-month-solve', year, month, userId],
+    queryFn: async () => await getMonthSolve({ userId, year, month }),
   });
 
   return data;

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -68,6 +68,6 @@ const TopContainer = styled.section`
 
 const GoTopBtn = styled.button`
   position: fixed;
-  top: 93rem;
-  right: 17.1rem;
+  top: calc(100vh - 15rem);
+  left: calc(100vw - 22.3rem);
 `;

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowUpBig } from '../assets';
@@ -16,6 +17,15 @@ const FollowerPage = () => {
   const userId = parseInt(id);
   const { data, isLoading } = useGetUserProfile(userId);
   const { nickname, isFollowing } = !isLoading && data?.data;
+
+  const [opacity, setOpacity] = useState(0);
+
+  useEffect(() => {
+    window.addEventListener('scroll', () => setOpacity(window.scrollY));
+    return () => {
+      window.removeEventListener('scroll', () => setOpacity(window.scrollY));
+    };
+  }, []);
 
   return (
     <PageLayout category="홈">
@@ -36,7 +46,11 @@ const FollowerPage = () => {
           <ParticipatingGroup nickname={nickname} />
 
           <FollowerRecommendCard />
-          <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
+          <GoTopBtn
+            type="button"
+            onClick={handleClickGoTopBtn}
+            $opacity={opacity}
+          >
             <IcArrowUpBig />
           </GoTopBtn>
         </FollowerPageContainer>
@@ -66,7 +80,9 @@ const TopContainer = styled.section`
   margin-bottom: 8.8rem;
 `;
 
-const GoTopBtn = styled.button`
+const GoTopBtn = styled.button<{ $opacity: number }>`
+  opacity: ${({ $opacity }) => $opacity};
+
   position: fixed;
   top: calc(100vh - 15rem);
   left: calc(100vw - 22.3rem);

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -11,7 +11,8 @@ import useGetUserProfile from '../libs/hooks/Follower/useGetUserProfile';
 const FollowerPage = () => {
   const { id } = useParams();
   if (!id) return;
-  const { data, isLoading } = useGetUserProfile(parseInt(id));
+  const userId = parseInt(id);
+  const { data, isLoading } = useGetUserProfile(userId);
   const { nickname, isFollowing } = !isLoading && data?.data;
 
   return (
@@ -21,7 +22,7 @@ const FollowerPage = () => {
           <TopContainer>
             <FollowerInfo info={data.data} />
 
-            <CommonMonthSolve />
+            <CommonMonthSolve userId={userId} />
           </TopContainer>
 
           <Solutions

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import CommonMonthSolve from '../common/CommonMonthSolve';
 import FollowerInfo from '../components/Follower/FollowerInfo';
 import FollowerRecommendCard from '../components/Follower/Personal/FollowerRecommendCard';
 import ParticipatingGroup from '../components/Follower/Personal/ParticipatingGroup';
@@ -20,8 +21,7 @@ const FollowerPage = () => {
           <TopContainer>
             <FollowerInfo info={data.data} />
 
-            {/* 나중에 다른 컴포넌트로 대체 예정 */}
-            <Temp></Temp>
+            <CommonMonthSolve />
           </TopContainer>
 
           <Solutions

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { IcArrowUpBig } from '../assets';
 import CommonMonthSolve from '../common/CommonMonthSolve';
 import FollowerInfo from '../components/Follower/FollowerInfo';
 import FollowerRecommendCard from '../components/Follower/Personal/FollowerRecommendCard';
@@ -7,6 +8,7 @@ import ParticipatingGroup from '../components/Follower/Personal/ParticipatingGro
 import Solutions from '../components/Follower/Personal/Solutions';
 import PageLayout from '../components/PageLayout/PageLayout';
 import useGetUserProfile from '../libs/hooks/Follower/useGetUserProfile';
+import { handleClickGoTopBtn } from '../utils/handleClickGoTopBtn';
 
 const FollowerPage = () => {
   const { id } = useParams();
@@ -34,6 +36,9 @@ const FollowerPage = () => {
           <ParticipatingGroup nickname={nickname} />
 
           <FollowerRecommendCard />
+          <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
+            <IcArrowUpBig />
+          </GoTopBtn>
         </FollowerPageContainer>
       )}
     </PageLayout>
@@ -46,6 +51,7 @@ const FollowerPageContainer = styled.section`
   display: flex;
   align-items: center;
   flex-direction: column;
+  position: relative;
 
   width: 100%;
   padding: 6.4rem 25.7rem 23.2rem;
@@ -60,11 +66,8 @@ const TopContainer = styled.section`
   margin-bottom: 8.8rem;
 `;
 
-// 나중에 지울 예정
-const Temp = styled.div`
-  flex-grow: 2;
-
-  min-width: 60.9rem;
-
-  height: 41rem;
+const GoTopBtn = styled.button`
+  position: fixed;
+  top: 93rem;
+  right: 17.1rem;
 `;

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonMonthSolve from '../common/CommonMonthSolve';
 import HomeHeader from '../components/Home/HomeHeader';
@@ -5,24 +7,25 @@ import TodaySolve from '../components/Home/TodaySolve';
 import WeeklyFollower from '../components/Home/WeekFollowing/WeeklyFollower';
 import WeekRate from '../components/Home/WeekRate';
 import PageLayout from '../components/PageLayout/PageLayout';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 const Home = () => {
-  const token = sessionStorage.getItem('token');
   const navigate = useNavigate();
+  const token = sessionStorage.getItem('token');
+  const user = sessionStorage.getItem('user');
+  if (!user) return;
+  const userId = parseInt(user);
 
   useEffect(() => {
     if (!token) {
       navigate('/login');
     }
   }, [token]);
-  
+
   return (
     <>
       <PageLayout category="홈">
         <HomeHeader />
         <MainContainer>
-          <CommonMonthSolve />
+          <CommonMonthSolve userId={userId} />
           <TodaySolve />
         </MainContainer>
         <FooterContainer>

--- a/src/page/SolvePage.tsx
+++ b/src/page/SolvePage.tsx
@@ -34,6 +34,7 @@ const SolvePage = () => {
     ],
   } = records || {};
 
+  const [opacity, setOpacity] = useState(0);
   const [questionInfo, setQuestionInfo] = useState<QuestionInfoProps>({
     title: '',
     level: 0,
@@ -137,50 +138,54 @@ const SolvePage = () => {
     }, [records]);
   }
 
+  useEffect(() => {
+    window.addEventListener('scroll', () => setOpacity(window.scrollY));
+    return () => {
+      window.removeEventListener('scroll', () => setOpacity(window.scrollY));
+    };
+  }, []);
+
   return (
     <PageLayout category="문제풀이">
-      <ScrollContainer>
-        {ideId > 0 && (
-          <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
-            <IcArrowUpBig />
-          </GoTopBtn>
-        )}
-        <SolvePageContainer>
-          <PageHeader
-            id={recordId}
-            isTemp={isTemp}
-            codeblocks={ideItems}
-            questionInfo={questionInfo}
-          />
+      {ideId > 0 && (
+        <GoTopBtn
+          type="button"
+          onClick={handleClickGoTopBtn}
+          $opacity={opacity}
+        >
+          <IcArrowUpBig />
+        </GoTopBtn>
+      )}
+      <SolvePageContainer>
+        <PageHeader
+          id={recordId}
+          isTemp={isTemp}
+          codeblocks={ideItems}
+          questionInfo={questionInfo}
+        />
 
-          <CodeSpace
-            ideItems={ideItems}
-            questionInfo={questionInfo}
-            handleClickQuestionInfo={handleClickQuestionInfo}
-            handleClickDeleteBtn={handleClickDeleteBtn}
-            handleChangeCode={handleChangeCode}
-            handleChangeMemo={handleChangeMemo}
-          />
+        <CodeSpace
+          ideItems={ideItems}
+          questionInfo={questionInfo}
+          handleClickQuestionInfo={handleClickQuestionInfo}
+          handleClickDeleteBtn={handleClickDeleteBtn}
+          handleChangeCode={handleChangeCode}
+          handleChangeMemo={handleChangeMemo}
+        />
 
-          <AddBtnContainer>
-            {ideItems[ideItems.length - 1].code.length ? (
-              <IcAddFill onClick={handleClickAddBtn} />
-            ) : (
-              <IcAddFillDisabled />
-            )}
-          </AddBtnContainer>
-        </SolvePageContainer>
-      </ScrollContainer>
+        <AddBtnContainer>
+          {ideItems[ideItems.length - 1].code.length ? (
+            <IcAddFill onClick={handleClickAddBtn} />
+          ) : (
+            <IcAddFillDisabled />
+          )}
+        </AddBtnContainer>
+      </SolvePageContainer>
     </PageLayout>
   );
 };
 
 export default SolvePage;
-
-const ScrollContainer = styled.div`
-  width: 100vw;
-  height: auto;
-`;
 
 const SolvePageContainer = styled.section`
   display: flex;
@@ -198,7 +203,9 @@ const AddBtnContainer = styled.div`
   margin: 1.8rem 25.7rem 0;
 `;
 
-const GoTopBtn = styled.button`
+const GoTopBtn = styled.button<{ $opacity: number }>`
+  opacity: ${({ $opacity }) => $opacity};
+
   position: fixed;
   top: calc(100vh - 15rem);
   left: calc(100vw - 22.3rem);

--- a/src/page/SolvePage.tsx
+++ b/src/page/SolvePage.tsx
@@ -194,7 +194,7 @@ const AddBtnContainer = styled.div`
 `;
 
 const GoTopBtn = styled.button`
-  position: absolute;
-  bottom: 25rem;
-  left: 121.7rem;
+  position: fixed;
+  top: 93rem;
+  right: 17.1rem;
 `;

--- a/src/page/SolvePage.tsx
+++ b/src/page/SolvePage.tsx
@@ -12,6 +12,7 @@ import {
   CodeProps,
   QuestionInfoProps,
 } from '../types/Solve/solveTypes';
+import { handleClickGoTopBtn } from '../utils/handleClickGoTopBtn';
 
 const SolvePage = () => {
   const { state } = useLocation();
@@ -103,10 +104,6 @@ const SolvePage = () => {
       ideItems: ideItems.filter((item) => item.id !== id),
       ideId: ideId - 1,
     });
-  };
-
-  const handleClickGoTopBtn = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const changeRecords = () => {

--- a/src/page/SolvePage.tsx
+++ b/src/page/SolvePage.tsx
@@ -108,7 +108,6 @@ const SolvePage = () => {
 
   const changeRecords = () => {
     setRecords(data.data);
-    console.log(data.data);
   };
 
   if (data) {
@@ -140,47 +139,53 @@ const SolvePage = () => {
 
   return (
     <PageLayout category="문제풀이">
-      <SolvePageContainer>
-        <PageHeader
-          id={recordId}
-          isTemp={isTemp}
-          codeblocks={ideItems}
-          questionInfo={questionInfo}
-        />
-
-        <CodeSpace
-          ideItems={ideItems}
-          questionInfo={questionInfo}
-          handleClickQuestionInfo={handleClickQuestionInfo}
-          handleClickDeleteBtn={handleClickDeleteBtn}
-          handleChangeCode={handleChangeCode}
-          handleChangeMemo={handleChangeMemo}
-        />
-
-        <AddBtnContainer>
-          {ideItems[ideItems.length - 1].code.length ? (
-            <IcAddFill onClick={handleClickAddBtn} />
-          ) : (
-            <IcAddFillDisabled />
-          )}
-        </AddBtnContainer>
+      <ScrollContainer>
         {ideId > 0 && (
           <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
             <IcArrowUpBig />
           </GoTopBtn>
         )}
-      </SolvePageContainer>
+        <SolvePageContainer>
+          <PageHeader
+            id={recordId}
+            isTemp={isTemp}
+            codeblocks={ideItems}
+            questionInfo={questionInfo}
+          />
+
+          <CodeSpace
+            ideItems={ideItems}
+            questionInfo={questionInfo}
+            handleClickQuestionInfo={handleClickQuestionInfo}
+            handleClickDeleteBtn={handleClickDeleteBtn}
+            handleChangeCode={handleChangeCode}
+            handleChangeMemo={handleChangeMemo}
+          />
+
+          <AddBtnContainer>
+            {ideItems[ideItems.length - 1].code.length ? (
+              <IcAddFill onClick={handleClickAddBtn} />
+            ) : (
+              <IcAddFillDisabled />
+            )}
+          </AddBtnContainer>
+        </SolvePageContainer>
+      </ScrollContainer>
     </PageLayout>
   );
 };
 
 export default SolvePage;
 
+const ScrollContainer = styled.div`
+  width: 100vw;
+  height: auto;
+`;
+
 const SolvePageContainer = styled.section`
   display: flex;
   align-items: center;
   flex-direction: column;
-  position: relative;
 
   padding: 6rem 25.7rem 20rem;
 `;
@@ -195,6 +200,6 @@ const AddBtnContainer = styled.div`
 
 const GoTopBtn = styled.button`
   position: fixed;
-  top: 93rem;
-  right: 17.1rem;
+  top: calc(100vh - 15rem);
+  left: calc(100vw - 22.3rem);
 `;

--- a/src/types/Home/getMonthSolveTypes.ts
+++ b/src/types/Home/getMonthSolveTypes.ts
@@ -1,4 +1,5 @@
 export interface getMonthSolveProps {
+  userId: number;
   year: number;
   month: number;
 }

--- a/src/utils/handleClickGoTopBtn.ts
+++ b/src/utils/handleClickGoTopBtn.ts
@@ -1,0 +1,3 @@
+export const handleClickGoTopBtn = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #146 

## ✅ 작업 내용

- [x] 팔로워 개인 뷰 그래프 구현
- [x] 위로 가기 버튼 구현 (solve 페이지 포함)

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/acd0df49-5696-4d82-9fdc-cf44aa2f7863

## 📌 이슈 사항
### 1️⃣ 그래프 구현
- 파이 그래프 두개 + label로 이미지 넣기 형태로 구현했습니다.
- 기존 승택오빠나 제가 했던 방식과 동일합니다 !

<br />

### 2️⃣ 위로가기 아이콘 구현
- 이 아이콘이 문제풀이 등록하기 뷰에도 사용되어서 두 군데 모두에서 개발했습니다
- 페이지 상단에 도착하면 더이상 해당 아이콘이 있는 의미가 없기때문에 투명도 0으로 변하게 구현했습니다.