### PR TITLE
[ GroupAll ] All 태그 눌렀을 시 그룹 렌더링 안되는 부분 수정

### DIFF
--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Groups from '../../common/Groups';
 import { SORTING } from '../../constants/Follower/currentConst';
 import useGetRoomsSort from '../../libs/hooks/GroupAll/useGetRoomSort';
+import { GroupsItemProps } from '../../types/GroupItem/groupItemType';
 import { removeSavedPage } from '../../utils/removeSavedPage';
 import LanguageSelectBox from './groupFilter/LanguageSelectBox';
 import SearchBar from './groupFilter/SearchBar';
@@ -44,7 +45,7 @@ const GroupItem = () => {
   const totalPageRef = useRef(totalPage || 1);
 
   // 필터링된 그룹 데이터를 반환하는 함수
-  const filterGroups = (groups: any[]) => {
+  const filterGroups = (groups: GroupsItemProps[]) => {
     const isAllTagSelected = selectedTags.includes(ALL_TAG);
 
     return groups.filter((group) => {

--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -45,14 +45,18 @@ const GroupItem = () => {
 
   // 필터링된 그룹 데이터를 반환하는 함수
   const filterGroups = (groups: any[]) => {
-    return groups.filter((group) => {
-      const isAllTagSelected = selectedTags.includes(ALL_TAG);
-      const groupHasAllTag = group.tags.includes(ALL_TAG);
+    const isAllTagSelected = selectedTags.includes(ALL_TAG);
 
+    return groups.filter((group) => {
+      // ALL_TAG가 선택된 경우, 태그 필터링을 건너뛰고 모든 그룹을 반환
+      if (isAllTagSelected) {
+        return true; // 모든 그룹 반환
+      }
+
+      // ALL_TAG가 선택되지 않았을 경우, 태그와 매칭된 그룹만 반환
       const tagMatch =
         selectedTags.length === 0 ||
-        (isAllTagSelected && groupHasAllTag) ||
-        selectedTags.every((tag) => group.tags.includes(tag)); // 인코딩되지 않은 상태로 비교
+        selectedTags.every((tag) => group.tags.includes(tag));
 
       const sliderMatch =
         group.memberCount >= sliderValues.min &&

--- a/src/types/GroupItem/groupItemType.ts
+++ b/src/types/GroupItem/groupItemType.ts
@@ -1,0 +1,5 @@
+export interface GroupsItemProps {
+  tags: string[];
+  memberCount: number;
+  capacity: number;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

## ✅ 작업 내용

## 📸 스크린샷 / GIF / Link
<img width="450" alt="image" src="https://github.com/user-attachments/assets/d0c41a30-d40c-4c5f-b0e3-cb1b323c5c8f">

All 태그 눌렀을 시 서버로 전송이 안된다는 말을 듣고, console.log를 찍어봤는데 데이터는 잘 들어오고 있었습니다. 

하지만 문제는 All 태그 그룹이 화면에 렌더링이 되지 않는것이 문제점이였습니다.

```const [searchResults, setSearchResults] = useState([]); ``` 이 코드는 검색창에 그룹을 찾아주는 state 였는데, 

배열로 들어가 있어서 콘솔을 찍어보니 그룹 전체값을 렌더링 해주고 있었습니다. 그래서 ALL 태그를 눌렀을 떄 값을 확인해보니,

<img width="449" alt="image" src="https://github.com/user-attachments/assets/5bb32ce0-1dc8-4f95-b142-740c7755782f">

사진과 같이 빈값이 들어가는걸 확인할 수 있었습니다. 

❗️ 그렇다면 필터링 처리 해주는 함수에서 수정을 한번 해보자 라는 생각이 들었습니다.

**수정전 코드**
```jsx
const filterGroups = (groups: any[]) => {
    return groups.filter((group) => {
      const isAllTagSelected = selectedTags.includes(ALL_TAG);
      const groupHasAllTag = group.tags.includes(ALL_TAG);

      const tagMatch =
        selectedTags.length === 0 ||
        (isAllTagSelected && groupHasAllTag) ||
        selectedTags.every((tag) => group.tags.includes(tag)); // 인코딩되지 않은 상태로 비교

      const sliderMatch =
        group.memberCount >= sliderValues.min &&
        group.capacity <= sliderValues.max;

      return tagMatch && sliderMatch;
    });
  };
```
 groupHasAllTag 부분에 group.tags.include 라고 되어있는데 이 부분에서 ALL_TAG 라는것이 존재하지 않습니다 
 
왜냐하면 Room 에는 모든 언어 태그가 들어가지 ALL_TAG 라고 들어가지있지는 않으니까요. 결국에는 group.tags 라는 부분이

렌더링이 되지 않아 작동되지 않았던 것이였습니다.

**수정된 코드**
```jsx
  const filterGroups = (groups: any[]) => {
    const isAllTagSelected = selectedTags.includes(ALL_TAG);

    return groups.filter((group) => {
      // ALL_TAG가 선택된 경우, 태그 필터링을 건너뛰고 모든 그룹을 반환
      if (isAllTagSelected) {
        return true; // 모든 그룹 반환
      }

      // ALL_TAG가 선택되지 않았을 경우, 태그와 매칭된 그룹만 반환
      const tagMatch =
        selectedTags.length === 0 ||
        selectedTags.every((tag) => group.tags.includes(tag));

      const sliderMatch =
        group.memberCount >= sliderValues.min &&
        group.capacity <= sliderValues.max;

      return tagMatch && sliderMatch;
    });
  };
```

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4e2ba286-7491-49ea-8cae-ee5f18a67454">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5b83418b-4710-4cb1-aa6d-01ca6250342a">



## 📌 이슈 사항

any 가 조금 거슬리는데 저걸 어떻게 바꿔줘야 할까요..

## ✍ 궁금한 것
