### PR TITLE
[ Alarm ] API 연결

### DIFF
--- a/src/assets/icon/ic_new_alarm.svg
+++ b/src/assets/icon/ic_new_alarm.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="7" viewBox="0 0 7 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="3.5" cy="3.5" r="3.5" fill="#08FF3F"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -48,6 +48,7 @@ import IcLogo from './icon/ic_logo.svg?react';
 import IcMemoGray from './icon/ic_memo_gray.svg?react';
 import IcMemoWhite from './icon/ic_memo_white.svg?react';
 import IcMinusWhite from './icon/ic_minus_white.svg?react';
+import IcNewAlarm from './icon/ic_new_alarm.svg?react';
 import IcNothing from './icon/ic_nothing.svg?react';
 import IcRank1 from './icon/ic_rank_1.svg?react';
 import IcRank2 from './icon/ic_rank_2.svg?react';
@@ -145,6 +146,7 @@ export {
   IcMemoGray,
   IcMemoWhite,
   IcMinusWhite,
+  IcNewAlarm,
   IcNothing,
   IcRank1,
   IcRank2,

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { IcNewAlarm } from '../assets';
 import usePostAlarmRead from '../libs/hooks/Alarm/usePostAlarmRead';
 import { AlarmModalProps } from '../types/Alarm/alarmType';
 
@@ -8,7 +9,6 @@ const AlarmModal = ({
   handleClose,
   notifications,
 }: AlarmModalProps) => {
-  // const { NEWALARMS, READALARMS } = ALARMLIST;
   // notifications가 로드되지 않았을 때 빈 배열을 기본값으로 설정
   const newAlarms =
     notifications?.filter((data) => data?.isRead === false) || [];
@@ -17,8 +17,8 @@ const AlarmModal = ({
   const { mutation } = usePostAlarmRead();
 
   const navigate = useNavigate();
-  // console.log('아이디값', id);
 
+  // 알람 클릭 시 일어나는 일
   const handleAlarmClick = (
     notificationIds: number,
     type: string,
@@ -41,7 +41,7 @@ const AlarmModal = ({
             navigate(`/group/${dataId}/admin`);
             break;
           case 'PUBLIC_ROOM_REQUEST':
-            navigate('group-complete');
+            navigate(`/group/${dataId}`);
             break;
           case 'PUBLIC_ROOM_APPROVE':
             navigate(`/group/${dataId}/member`);
@@ -69,20 +69,17 @@ const AlarmModal = ({
                   handleAlarmClick(data.notificationId, data.type, data.dataId)
                 }
               >
-                {/* <Highlight>{data.content}</Highlight> */}
                 {data.content}
+                <IcContainer>
+                  <IcNewAlarm />
+                </IcContainer>
               </ModalTab>
             );
           })}
           <Divider />
           <Title>읽음</Title>
           {readAlarms.map((data, idx) => {
-            return (
-              <ModalTab key={idx}>
-                {/* <Highlight>{data.groupName}</Highlight> */}
-                {data.content}
-              </ModalTab>
-            );
+            return <ModalTab key={idx}>{data.content}</ModalTab>;
           })}
         </ModalContainer>
       )}
@@ -108,11 +105,16 @@ const ModalContainer = styled.ul`
 `;
 
 const ModalTab = styled.li`
+  display: flex;
+  position: relative;
+
   width: 100%;
   padding: 1.1rem 3.9rem 1.1rem 2.2rem;
   ${({ theme }) => theme.fonts.title_regular_14};
 
   color: ${({ theme }) => theme.colors.white};
+
+  white-space: nowrap;
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.gray500};
@@ -139,7 +141,13 @@ const Divider = styled.div`
   background-color: ${({ theme }) => theme.colors.gray500};
 `;
 
-// const Highlight = styled.span`
-//   ${({ theme }) => theme.fonts.title_semiBold_14};
-//   color: ${({ theme }) => theme.colors.white};
-// `;
+const IcContainer = styled.div`
+  display: flex;
+  position: absolute;
+  top: 1.1rem;
+  right: 2.2rem;
+
+  /* margin-left: 9.5rem; */
+
+  /* background-color: pink; */
+`;

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import usePostAlarmRead from '../libs/hooks/Alarm/usePostAlarmRead';
 import { AlarmModalProps } from '../types/Alarm/alarmType';
@@ -15,15 +15,19 @@ const AlarmModal = ({
   const readAlarms =
     notifications?.filter((data) => data?.isRead === true) || [];
   const { mutation } = usePostAlarmRead();
-  // console.log(mutation);
 
   const navigate = useNavigate();
-  const { id } = useParams();
+  // console.log('아이디값', id);
 
-  console.log(id);
+  const handleAlarmClick = (
+    notificationIds: number,
+    type: string,
+    dataId: number
+  ) => {
+    console.log('알람클릭:', notificationIds); // 클릭 시 로그 출력
+    console.log(dataId);
+    console.log('타입', type);
 
-  const handleAlarmClick = (notificationIds: number, type: string) => {
-    console.log('Alarm clicked:', notificationIds, type); // 클릭 시 로그 출력
     mutation(notificationIds, {
       onSuccess: () => {
         switch (type) {
@@ -31,20 +35,22 @@ const AlarmModal = ({
             navigate('/follower');
             break;
           case 'CREATED_PUBLIC_ROOM_REQUEST':
-            navigate(`/group/${id}/admin`);
+            navigate(`/group/${dataId}/admin`);
             break;
-          case 'CREATED_PRIVATE_ROOM_REQUEST':
-            navigate(`/group/${id}/admin`);
+          case 'CREATED_PRIVATE_ROOM_JOIN':
+            navigate(`/group/${dataId}/admin`);
             break;
-          case 'PUBLIC_ROOM_REQUSET':
+          case 'PUBLIC_ROOM_REQUEST':
             navigate('group-complete');
             break;
           case 'PUBLIC_ROOM_APPROVE':
-            navigate(`/group/${id}/member`);
+            navigate(`/group/${dataId}/member`);
             break;
           case 'ROOM_STATUS_INACTIVE':
             navigate('/group/my-page');
             break;
+          default:
+            console.log('매치된거없음', type);
         }
       },
     });
@@ -59,7 +65,9 @@ const AlarmModal = ({
             return (
               <ModalTab
                 key={idx}
-                onClick={() => handleAlarmClick(data.notificationId, data.type)}
+                onClick={() =>
+                  handleAlarmClick(data.notificationId, data.type, data.dataId)
+                }
               >
                 {/* <Highlight>{data.content}</Highlight> */}
                 {data.content}

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,4 +1,6 @@
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import usePostAlarmRead from '../libs/hooks/Alarm/usePostAlarmRead';
 import { AlarmModalProps } from '../types/Alarm/alarmType';
 
 const AlarmModal = ({
@@ -7,8 +9,46 @@ const AlarmModal = ({
   notifications,
 }: AlarmModalProps) => {
   // const { NEWALARMS, READALARMS } = ALARMLIST;
-  const newAlarms = notifications.filter((data) => data.isRead === false);
-  const readAlarms = notifications.filter((data) => data.isRead === true);
+  // notifications가 로드되지 않았을 때 빈 배열을 기본값으로 설정
+  const newAlarms =
+    notifications?.filter((data) => data?.isRead === false) || [];
+  const readAlarms =
+    notifications?.filter((data) => data?.isRead === true) || [];
+  const { mutation } = usePostAlarmRead();
+  // console.log(mutation);
+
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  console.log(id);
+
+  const handleAlarmClick = (notificationIds: number, type: string) => {
+    console.log('Alarm clicked:', notificationIds, type); // 클릭 시 로그 출력
+    mutation(notificationIds, {
+      onSuccess: () => {
+        switch (type) {
+          case 'FOLLOW':
+            navigate('/follower');
+            break;
+          case 'CREATED_PUBLIC_ROOM_REQUEST':
+            navigate(`/group/${id}/admin`);
+            break;
+          case 'CREATED_PRIVATE_ROOM_REQUEST':
+            navigate(`/group/${id}/admin`);
+            break;
+          case 'PUBLIC_ROOM_REQUSET':
+            navigate('group-complete');
+            break;
+          case 'PUBLIC_ROOM_APPROVE':
+            navigate(`/group/${id}/member`);
+            break;
+          case 'ROOM_STATUS_INACTIVE':
+            navigate('/group/my-page');
+            break;
+        }
+      },
+    });
+  };
 
   return (
     <>
@@ -17,7 +57,10 @@ const AlarmModal = ({
           <Title>새로운 알림</Title>
           {newAlarms.map((data, idx) => {
             return (
-              <ModalTab key={idx}>
+              <ModalTab
+                key={idx}
+                onClick={() => handleAlarmClick(data.notificationId, data.type)}
+              >
                 {/* <Highlight>{data.content}</Highlight> */}
                 {data.content}
               </ModalTab>

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -37,7 +37,9 @@ const AlarmModal = ({
             navigate(`/group/${dataId}/admin`);
             break;
           case 'PUBLIC_ROOM_REQUEST':
-            navigate(`/group/${dataId}`);
+            navigate(`/group/${dataId}`, {
+              state: { disabledApply: true },
+            }); // state 를 true로 변경하여 신청하기 버튼 없애기
             break;
           case 'PUBLIC_ROOM_APPROVE':
             navigate(`/group/${dataId}/member`);

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -18,16 +18,12 @@ const AlarmModal = ({
 
   const navigate = useNavigate();
 
-  // 알람 클릭 시 일어나는 일
+  // notifications 에서 data 전달
   const handleAlarmClick = (
     notificationIds: number,
     type: string,
     dataId: number
   ) => {
-    console.log('알람클릭:', notificationIds); // 클릭 시 로그 출력
-    console.log(dataId);
-    console.log('타입', type);
-
     mutation(notificationIds, {
       onSuccess: () => {
         switch (type) {
@@ -49,8 +45,6 @@ const AlarmModal = ({
           case 'ROOM_STATUS_INACTIVE':
             navigate('/group/my-page');
             break;
-          default:
-            console.log('매치된거없음', type);
         }
       },
     });
@@ -68,6 +62,7 @@ const AlarmModal = ({
                 onClick={() =>
                   handleAlarmClick(data.notificationId, data.type, data.dataId)
                 }
+                /* 알림 클릭 시 type,dataId,notificationId 전달 */
               >
                 {data.content}
                 <IcContainer>
@@ -146,8 +141,4 @@ const IcContainer = styled.div`
   position: absolute;
   top: 1.1rem;
   right: 2.2rem;
-
-  /* margin-left: 9.5rem; */
-
-  /* background-color: pink; */
 `;

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,30 +1,35 @@
 import styled from 'styled-components';
-import { ALARMLIST } from '../constants/Alarm/alarm';
 import { AlarmModalProps } from '../types/Alarm/alarmType';
 
-const AlarmModal = ({ isOpen, handleClose }: AlarmModalProps) => {
-  const { NEWALARMS, READALARMS } = ALARMLIST;
+const AlarmModal = ({
+  isOpen,
+  handleClose,
+  notifications,
+}: AlarmModalProps) => {
+  // const { NEWALARMS, READALARMS } = ALARMLIST;
+  const newAlarms = notifications.filter((data) => data.isRead === false);
+  const readAlarms = notifications.filter((data) => data.isRead === true);
 
   return (
     <>
       {isOpen && (
         <ModalContainer onMouseLeave={handleClose}>
           <Title>새로운 알림</Title>
-          {NEWALARMS.map((data, idx) => {
+          {newAlarms.map((data, idx) => {
             return (
               <ModalTab key={idx}>
-                <Highlight>{data.groupName}</Highlight>
-                {data.message}
+                {/* <Highlight>{data.content}</Highlight> */}
+                {data.content}
               </ModalTab>
             );
           })}
           <Divider />
           <Title>읽음</Title>
-          {READALARMS.map((data, idx) => {
+          {readAlarms.map((data, idx) => {
             return (
               <ModalTab key={idx}>
-                <Highlight>{data.groupName}</Highlight>
-                {data.message}
+                {/* <Highlight>{data.groupName}</Highlight> */}
+                {data.content}
               </ModalTab>
             );
           })}
@@ -83,7 +88,7 @@ const Divider = styled.div`
   background-color: ${({ theme }) => theme.colors.gray500};
 `;
 
-const Highlight = styled.span`
-  ${({ theme }) => theme.fonts.title_semiBold_14};
-  color: ${({ theme }) => theme.colors.white};
-`;
+// const Highlight = styled.span`
+//   ${({ theme }) => theme.fonts.title_semiBold_14};
+//   color: ${({ theme }) => theme.colors.white};
+// `;

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -58,12 +58,11 @@ const AlarmModal = ({
         <ModalContainer onMouseLeave={handleClose}>
           <Title>새로운 알림</Title>
           {newAlarms.map((data, idx) => {
+            const { notificationId, type, dataId } = data;
             return (
               <ModalTab
                 key={idx}
-                onClick={() =>
-                  handleAlarmClick(data.notificationId, data.type, data.dataId)
-                }
+                onClick={() => handleAlarmClick(notificationId, type, dataId)}
                 /* 알림 클릭 시 type,dataId,notificationId 전달 */
               >
                 {data.content}
@@ -76,7 +75,8 @@ const AlarmModal = ({
           <Divider />
           <Title>읽음</Title>
           {readAlarms.map((data, idx) => {
-            return <ModalTab key={idx}>{data.content}</ModalTab>;
+            const { content } = data;
+            return <ModalTab key={idx}>{content}</ModalTab>;
           })}
         </ModalContainer>
       )}

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcNewAlarm } from '../assets';
 import usePostAlarmRead from '../libs/hooks/Alarm/usePostAlarmRead';
@@ -16,40 +15,13 @@ const AlarmModal = ({
     notifications?.filter((data) => data?.isRead === true) || [];
   const { mutation } = usePostAlarmRead();
 
-  const navigate = useNavigate();
-
   // notifications 에서 data 전달
   const handleAlarmClick = (
-    notificationIds: number,
+    notificationId: number,
     type: string,
     dataId: number
   ) => {
-    mutation(notificationIds, {
-      onSuccess: () => {
-        switch (type) {
-          case 'FOLLOW':
-            navigate('/follower');
-            break;
-          case 'CREATED_PUBLIC_ROOM_REQUEST':
-            navigate(`/group/${dataId}/admin`);
-            break;
-          case 'CREATED_PRIVATE_ROOM_JOIN':
-            navigate(`/group/${dataId}/admin`);
-            break;
-          case 'PUBLIC_ROOM_REQUEST':
-            navigate(`/group/${dataId}`, {
-              state: { disabledApply: true },
-            }); // state 를 true로 변경하여 신청하기 버튼 없애기
-            break;
-          case 'PUBLIC_ROOM_APPROVE':
-            navigate(`/group/${dataId}/member`);
-            break;
-          case 'ROOM_STATUS_INACTIVE':
-            navigate('/group/my-page');
-            break;
-        }
-      },
-    });
+    mutation({ notificationId, type, dataId });
   };
 
   return (

--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -67,10 +67,13 @@ const ModalContainer = styled.ul`
   right: -2rem;
 
   width: 36.4rem;
+  max-height: 53rem;
+
   padding: 2.2rem 0 1.8rem;
 
   border-radius: 1rem;
   background-color: ${({ theme }) => theme.colors.gray600};
+  overflow-y: scroll;
 `;
 
 const ModalTab = styled.li`

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -34,9 +34,10 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   const handleCloseAlarm = () => {
     setIsAlarmOpen(false);
   };
+
+  // 알람 리스트 전부를 받아와서 notifications 의 담아줌
   const { data, isLoading } = useGetAlarmList();
   const { notifications } = !isLoading && data?.data;
-  console.log(notifications);
 
   // HeaderContainer 에 Leave 있는 이유는 Gnb 컨텐츠 부분을 꼭 지나치고 마우스를 나가야만 창이 닫혀서
   // 컨텐츠 부분을 지나치지 않더라도 바로 창이 닫히게끔 하기 위해 추가함

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowBottomWhite, IcLoginIcon, IcLogo } from '../assets';
 import { DATA } from '../constants/Header/HeaderConst';
+import useGetAlarmList from '../libs/hooks/Alarm/useGetAlarmList';
 import { HeaderProps } from '../types/Header/HeaderType';
 import AlarmModal from './AlarmModal';
 import Gnb from './Gnb';
@@ -33,6 +34,9 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   const handleCloseAlarm = () => {
     setIsAlarmOpen(false);
   };
+  const { data, isLoading } = useGetAlarmList();
+  const { notifications } = !isLoading && data?.data;
+  console.log(notifications);
 
   // HeaderContainer 에 Leave 있는 이유는 Gnb 컨텐츠 부분을 꼭 지나치고 마우스를 나가야만 창이 닫혀서
   // 컨텐츠 부분을 지나치지 않더라도 바로 창이 닫히게끔 하기 위해 추가함
@@ -85,7 +89,11 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
         </LoginBtnContainer>
         <AlarmContainer>
           {isAlarmOpen && (
-            <AlarmModal isOpen={isAlarmOpen} handleClose={handleCloseAlarm} />
+            <AlarmModal
+              isOpen={isAlarmOpen}
+              handleClose={handleCloseAlarm}
+              notifications={notifications}
+            />
           )}
         </AlarmContainer>
         <IcArrowContainer

--- a/src/libs/apis/Alarm/getAlarmList.ts
+++ b/src/libs/apis/Alarm/getAlarmList.ts
@@ -1,0 +1,9 @@
+import { api } from '../../api';
+
+const getAlarmList = async () => {
+  const { data } = await api.get('/notifications/list');
+
+  return data;
+};
+
+export default getAlarmList;

--- a/src/libs/apis/Alarm/postAlarmRead.ts
+++ b/src/libs/apis/Alarm/postAlarmRead.ts
@@ -2,6 +2,7 @@ import { api } from '../../api';
 
 const postAlarmRead = async (notificationIds: number) => {
   const { data } = await api.post('/notifications/read', {
+    // requestBody에서 배열로 받아옴
     notificationIds: [notificationIds],
   });
 

--- a/src/libs/apis/Alarm/postAlarmRead.ts
+++ b/src/libs/apis/Alarm/postAlarmRead.ts
@@ -1,0 +1,11 @@
+import { api } from '../../api';
+
+const postAlarmRead = async (notificationIds: number) => {
+  const { data } = await api.post('/notifications/read', {
+    notificationIds: [notificationIds],
+  });
+
+  return data;
+};
+
+export default postAlarmRead;

--- a/src/libs/hooks/Alarm/useGetAlarmList.ts
+++ b/src/libs/hooks/Alarm/useGetAlarmList.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import getAlarmList from '../../apis/Alarm/getAlarmList';
+
+const useGetAlarmList = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['get-alarm-list'],
+    queryFn: async () => await getAlarmList(),
+  });
+
+  return { data, isLoading };
+};
+
+export default useGetAlarmList;

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -2,14 +2,49 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import postAlarmRead from '../../apis/Alarm/postAlarmRead';
 
+import { useNavigate } from 'react-router-dom';
+
 const usePostAlarmRead = () => {
   const [errMsg, setErrMsg] = useState('');
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const mutation = useMutation({
-    mutationFn: async (notificationIds: number) =>
-      await postAlarmRead(notificationIds),
-    onSuccess: () => {
+    mutationFn: async ({
+      notificationId,
+      type,
+      dataId,
+    }: {
+      notificationId: number;
+      type: string;
+      dataId: number;
+    }) => {
+      await postAlarmRead(notificationId);
+      return { type, dataId };
+    },
+    onSuccess: ({ type, dataId }: { type: string; dataId: number }) => {
+      switch (type) {
+        case 'FOLLOW':
+          navigate(`/follower`);
+          break;
+        case 'CREATED_PUBLIC_ROOM_REQUEST':
+          navigate(`/group/${dataId}/admin`);
+          break;
+        case 'CREATED_PRIVATE_ROOM_JOIN':
+          navigate(`/group/${dataId}/admin`);
+          break;
+        case 'PUBLIC_ROOM_REQUEST':
+          navigate(`/group/${dataId}`, {
+            state: { disabledApply: true },
+          }); // state 를 true로 변경하여 신청하기 버튼 없애기
+          break;
+        case 'PUBLIC_ROOM_APPROVE':
+          navigate(`/group/${dataId}/member`);
+          break;
+        case 'ROOM_STATUS_INACTIVE':
+          navigate('/group/my-page');
+          break;
+      }
       queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });
       queryClient.invalidateQueries({ queryKey: ['get-alarm-list'] });
     },

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import postAlarmRead from '../../apis/Alarm/postAlarmRead';
+
+const usePostAlarmRead = () => {
+  const [errMsg, setErrMsg] = useState('');
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (notificationIds: number) =>
+      await postAlarmRead(notificationIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });
+      queryClient.invalidateQueries({ queryKey: ['get-alarm-list'] });
+    },
+    onError: (err: { response: { data: { message: string } } }) => {
+      const { message } = err.response.data;
+      setErrMsg(message);
+    },
+  });
+
+  return { mutation: mutation.mutate, readErr: errMsg };
+};
+
+export default usePostAlarmRead;

--- a/src/types/Alarm/alarmType.ts
+++ b/src/types/Alarm/alarmType.ts
@@ -7,6 +7,7 @@ export interface AlarmModalProps {
       isRead: boolean;
       notificationId: number;
       type: string;
+      dataId: number;
     },
   ];
 }

--- a/src/types/Alarm/alarmType.ts
+++ b/src/types/Alarm/alarmType.ts
@@ -5,6 +5,8 @@ export interface AlarmModalProps {
     {
       content: string;
       isRead: boolean;
+      notificationId: number;
+      type: string;
     },
   ];
 }

--- a/src/types/Alarm/alarmType.ts
+++ b/src/types/Alarm/alarmType.ts
@@ -1,4 +1,10 @@
 export interface AlarmModalProps {
   isOpen: boolean;
   handleClose: () => void;
+  notifications: [
+    {
+      content: string;
+      isRead: boolean;
+    },
+  ];
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #260 

## ✅ 작업 내용

- [x] 알림 목록 조회해서 렌더링하기
- [x] 알림 읽음 처리 해주기
- [x] 새로운 알림이 올 시 아이콘 처리해주기

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
### 1️⃣ 알림 목록 조회
```jsx
// Header.tsx
const { data, isLoading } = useGetAlarmList();
  const { notifications } = !isLoading && data?.data;
};
```
notifications 안에 있는 데이터들을 AlarmModal 컴포넌트로 데이터를 내려주었습니다.

![image](https://github.com/user-attachments/assets/d77c8748-048e-4292-9650-b499a3ac67fd)


### 2️⃣ 읽음,안읽음 처리해주기
알림 스트림 등록과 해제가 있긴 하였지만 , 읽음 목록 조회를 테스트 해보기 위해서 새로운 알림과 알림 읽음 목록을 분기처리 하였습니다.

filter 처리를 해주어서 isRead 가 false 면 새로운 알림, true 이면 읽음 알림으로 처리해주었습니다.

렌더링될 때 서버에서 undefiend가 잠깐 처리되고 그 후 데이터를 가져오는 형식이여서 data가 로드되지 않았을 때 배열을 빈 배열로 처리해주어 오류를 막아주었습니다.
```jsx
// notifications가 로드되지 않았을 때 빈 배열을 기본값으로 설정
// AlarmModal.tsx
  const newAlarms =
    notifications?.filter((data) => data?.isRead === false) || [];
  const readAlarms =
    notifications?.filter((data) => data?.isRead === true) || [];
  const { mutation } = usePostAlarmRead();
```

### 3️⃣ 알림을 클릭했을 때 navigate
여기서 제일 애먹었던것 같습니다.. 사실 onSuccess 를 useQuery 안에서 처리해주고 싶었는데 조금 급하게 하다보니 어떻게 해야할지 몰라서 일단 작성은 하였습니다. 여기서 onSuceess 를 안쓰고 어떻게 처리해야할지 피드백 부탁드립니다ㅠ

우선 onSuceess 를 사용한 이유는 mutation 함수가 비동기 작업이기 때문에 onSuccess 없이 바로 navigate를 실행하게 되면 API 요청이 끝나기 전에 페이지가 이동할 수 있기 때문입니다. 순서를 보장하기 위해 사용하였습니다.

PUBLIC_ROOM_REQUEST 에서 state를 넣어준 이유는 이미 한번 신청한 상태에서 신청하기 버튼을 또 한번 보여줄 필요가 없기 때문에 그 버튼을 없애기 위해 state를 실어서 보냈습니다.

```jsx
// AlarmModal.tsx
  const navigate = useNavigate();

  // notifications 에서 data 전달
  const handleAlarmClick = (
    notificationIds: number,
    type: string,
    dataId: number
  ) => {
    mutation(notificationIds, {
      onSuccess: () => {
        switch (type) {
          case 'FOLLOW':
            navigate('/follower');
            break;
          case 'CREATED_PUBLIC_ROOM_REQUEST':
            navigate(`/group/${dataId}/admin`);
            break;
          case 'CREATED_PRIVATE_ROOM_JOIN':
            navigate(`/group/${dataId}/admin`);
            break;
          case 'PUBLIC_ROOM_REQUEST':
            navigate(`/group/${dataId}`, {
              state: { disabledApply: true },
            }); // state 를 true로 변경하여 신청하기 버튼 없애기
            break;
          case 'PUBLIC_ROOM_APPROVE':
            navigate(`/group/${dataId}/member`);
            break;
          case 'ROOM_STATUS_INACTIVE':
            navigate('/group/my-page');
            break;
        }
      },
    });
  };
```

알림 버튼을 누르기 전 그룹 디테일 페이지
<img width="400" alt="image" src="https://github.com/user-attachments/assets/617befda-fb38-46ee-b6e0-7b0a0dd2d826">


알림 버튼을 누른 후 그룹 디테일 페이지
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ad6c3049-e439-40e6-8365-cacb4d7594d0">


## ✍ 궁금한 것
onSuccess 처리를 커스텀 훅 안에서 처리를 하고 싶은데 어떻게 해야할까요 
