### PR TITLE
[ Hotfix ] 새로운 알림이 없음에도 프로필 사진에 초록색 동그라미 없어지지 않는 이슈 해결

### DIFF
--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -28,7 +28,7 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   const [hoveredCategory, setHoveredCategory] = useState('');
   const [isGnbOpen, setIsGnbOpen] = useState(false);
   const [isAlarmOpen, setIsAlarmOpen] = useState(false);
-  const [isNewAlarmExit, setIsNewAlarmExit] = useState(false);
+  const [isNewAlarmExit, setIsNewAlarmExit] = useState(newAlarms.length > 0);
 
   // Profile 호버만 따로 하기 위해 사용
   const isHoveredProfile = hoveredCategory === 'profile';
@@ -49,9 +49,7 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   };
 
   useEffect(() => {
-    const hasNewAlarms = newAlarms || sessionStorage.getItem('isNewAlarmExit');
-
-    if (hasNewAlarms) {
+    if (newAlarms.length > 0) {
       sessionStorage.setItem('isNewAlarmExit', 'true');
       setIsNewAlarmExit(true);
     } else {


### PR DESCRIPTION


## ✅ 작업 내용

- [x] 새로운 알림이 없음에도 프로필 사진에 초록색 동그라미 없어지지 않는 이슈 해결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/26f52f1d-4cde-457b-b5f9-82763c539723



## 📌 이슈 사항
### 1️⃣ 새로운 알림이 없음에도 프로필 사진에 초록색 동그라미 없어지지 않는 이슈 해결
- 새로운 알림 여부에 따라 state 값이 변하도록 구현해놨는데, 이때 새로운 알림 유/무를 판단하는 조건이 잘못되어서 발생한 문제였어요.
- 이걸 해결하기 위해서 state의 초기 값을 `newAlarms.length > 0`로 설정하여 해당 조건을 만족한 경우 true, 그렇지 않은 경우 false 값을 갖도록 정의했어요.
이후 새로운 알림이 들어올 때마다 동작하는 useEffect 문 내부에도 newAlarms.length > 0인 경우 state 값을 true, 그렇지 않은 경우 false를 할당하여, 새로운 알림 유/무에 따라 프로필 사진에 초록색 동그라미가 제대로 뜨도록 구현했습니다.
