### PR TITLE
[ Hotfix ] 기존 로직과 다르게 동작하는 부분 수정

### DIFF
--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcNewAlarm } from '../assets';
 import usePostAlarmRead from '../libs/hooks/Alarm/usePostAlarmRead';
@@ -15,8 +14,6 @@ const AlarmModal = ({
 
   const { mutation } = usePostAlarmRead();
 
-  const navigate = useNavigate();
-
   // notifications 에서 data 전달
   const handleAlarmClick = (
     notificationId: number,
@@ -24,7 +21,6 @@ const AlarmModal = ({
     dataId: number
   ) => {
     mutation({ notificationId, type, dataId });
-    navigate(`/${type}/${dataId}`);
   };
 
   return (
@@ -55,9 +51,9 @@ const AlarmModal = ({
           <Divider />
           <Title>읽음</Title>
           {readAlarms.map((data, idx) => {
-            // const { content } = data;
-            const bracketText = data.content.match(/\[[^\]]+\]/g);
-            const nonBracketText = data.content.split(/\[[^\]]+\]/);
+            const { content } = data;
+            const bracketText = content.match(/\[[^\]]+\]/g);
+            const nonBracketText = content.split(/\[[^\]]+\]/);
             return (
               <ModalTab key={idx}>
                 <AlarmTitle>{bracketText}</AlarmTitle>

--- a/src/components/Follower/Personal/FollowerRecommendCard.tsx
+++ b/src/components/Follower/Personal/FollowerRecommendCard.tsx
@@ -62,12 +62,14 @@ const FollowerRecommendCard = () => {
         <MyNickname>{myNickname}</MyNickname>
         <Title>님을 위한 추천</Title>
 
-        <IcInformation />
-        <InformationTooltip
-          myNickname={`${myNickname}`}
-          topContents="님 만을 위해"
-          bottomContents="하루에 6명씩 랜덤으로 개발자를 추천해드려요"
-        />
+        <InformaitonContainer>
+          <IcInformation />
+          <InformationTooltip
+            myNickname={`${myNickname}`}
+            topContents="님 만을 위해"
+            bottomContents="하루에 6명씩 랜덤으로 개발자를 추천해드려요"
+          />
+        </InformaitonContainer>
       </TitleContainer>
 
       {!isLoading && (
@@ -153,17 +155,8 @@ const RecommendCardContainer = styled.article`
 const TitleContainer = styled.div`
   display: flex;
   align-items: center;
-  position: relative;
 
   margin-left: 0.3rem;
-
-  &:hover > div {
-    visibility: visible;
-
-    margin-left: 24.4rem;
-
-    opacity: 1;
-  }
 `;
 
 const MyNickname = styled.p`
@@ -178,6 +171,17 @@ const Title = styled.p`
 
   ${({ theme }) => theme.fonts.title_bold_20};
   color: ${({ theme }) => theme.colors.white};
+`;
+
+const InformaitonContainer = styled.div`
+  position: relative;
+
+  &:hover > div {
+    visibility: visible;
+
+    margin: -0.3rem 0 0 -0.1rem;
+    opacity: 1;
+  }
 `;
 
 const RecommendCard = styled.article`

--- a/src/components/GroupDetail/ApplicationModal.tsx
+++ b/src/components/GroupDetail/ApplicationModal.tsx
@@ -61,7 +61,7 @@ const ApplicationModal = ({ id, onClose }: ApplicationModalProps) => {
                   </Applicants>
                 </ApplicantsContainer>
                 <JoinedNumContainer>
-                  <JoinedNum>{approvedCount - 1}</JoinedNum>
+                  <JoinedNum>{approvedCount}</JoinedNum>
                   <JoinedText>명 승인</JoinedText>
                 </JoinedNumContainer>
               </Modal>

--- a/src/libs/hooks/Admin/useGetParticipantsList.ts
+++ b/src/libs/hooks/Admin/useGetParticipantsList.ts
@@ -8,7 +8,7 @@ const useGetParticipantsList = ({
   page,
 }: GetMemberListProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-participants-list', page, sortType],
+    queryKey: ['get-participants-list', page, sortType, groupId],
     queryFn: async () => await getParticipantsList({ groupId, sortType, page }),
   });
 

--- a/src/libs/hooks/Admin/useGetRoomInfo.ts
+++ b/src/libs/hooks/Admin/useGetRoomInfo.ts
@@ -4,7 +4,7 @@ import getRoomInfo from '../../apis/Admin/getRoomInfo';
 
 const useGetRoomInfo = ({ roomId }: GetRoomInfoProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-room-info'],
+    queryKey: ['get-room-info', roomId],
     queryFn: async () => await getRoomInfo({ roomId }),
   });
 

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -40,7 +40,7 @@ const usePostAlarmRead = () => {
           navigate(`/group/${dataId}/member`);
           break;
         case 'ROOM_STATUS_INACTIVE':
-          navigate('/group/my-page');
+          navigate('/my-group');
           break;
       }
       queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -1,11 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
 import postAlarmRead from '../../apis/Alarm/postAlarmRead';
 
 import { useNavigate } from 'react-router-dom';
 
 const usePostAlarmRead = () => {
-  const [errMsg, setErrMsg] = useState('');
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -48,13 +46,9 @@ const usePostAlarmRead = () => {
       queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });
       queryClient.invalidateQueries({ queryKey: ['get-alarm-list'] });
     },
-    onError: (err: { response: { data: { message: string } } }) => {
-      const { message } = err.response.data;
-      setErrMsg(message);
-    },
   });
 
-  return { mutation: mutation.mutate, readErr: errMsg };
+  return { mutation: mutation.mutate };
 };
 
 export default usePostAlarmRead;

--- a/src/libs/hooks/Follower/useGetUserProfile.ts
+++ b/src/libs/hooks/Follower/useGetUserProfile.ts
@@ -4,7 +4,7 @@ import getUserProfile from '../../apis/Follower/getUserProfile';
 const useGetUserProfile = (userId?: number) => {
   if (userId) {
     const { data, isLoading } = useQuery({
-      queryKey: ['get-user-profile'],
+      queryKey: ['get-user-profile', userId],
       queryFn: async () => await getUserProfile(userId),
     });
 

--- a/src/libs/hooks/GroupDetail/useGetDetail.ts
+++ b/src/libs/hooks/GroupDetail/useGetDetail.ts
@@ -3,7 +3,7 @@ import getDetail from '../../apis/GroupDetail/getDetail';
 
 const useGetDetail = (id: number) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-detail'],
+    queryKey: ['get-detail', id],
     queryFn: async () => await getDetail(id),
   });
 

--- a/src/libs/hooks/GroupMember/useGetMemberList.ts
+++ b/src/libs/hooks/GroupMember/useGetMemberList.ts
@@ -4,7 +4,7 @@ import getMeberList from '../../apis/GroupMember/getMeberList';
 
 const useGetMemberList = ({ groupId, sortType, page }: GetMemberListProps) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-member-list', page, sortType],
+    queryKey: ['get-member-list', page, sortType, groupId],
     queryFn: async () => await getMeberList({ groupId, sortType, page }),
   });
 

--- a/src/libs/hooks/GroupMember/useGetRanking.ts
+++ b/src/libs/hooks/GroupMember/useGetRanking.ts
@@ -3,7 +3,7 @@ import getRanking from '../../apis/GroupMember/getRanking';
 
 const useGetRanking = (roomId: number) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['get-ranking'],
+    queryKey: ['get-ranking', roomId],
     queryFn: async () => await getRanking(roomId),
     enabled: !!roomId,
   });

--- a/src/page/FollowerCurrentPage.tsx
+++ b/src/page/FollowerCurrentPage.tsx
@@ -8,6 +8,7 @@ import { updateWeek } from '../utils/updateWeek';
 const FollowerCurrentPage = () => {
   const { startDate, endDate } = updateWeek();
   const [sMonth, sDate] = startDate.split(' ');
+  const [eMonth, eDate] = endDate.split(' ');
 
   useEffect(() => {
     updateWeek();
@@ -18,7 +19,7 @@ const FollowerCurrentPage = () => {
       <FollowerCurrentPageContainer>
         <Header>
           <Title>주간 팔로잉 현황</Title>
-          <Date>{`${sMonth}월 ${sDate}일 - ${endDate}일`}</Date>
+          <Date>{`${sMonth}월 ${sDate}일 - ${eMonth}월 ${eDate}일`}</Date>
         </Header>
 
         <FollowerQuestions />

--- a/src/utils/updateWeek.ts
+++ b/src/utils/updateWeek.ts
@@ -33,9 +33,9 @@ const updateEndDate = (today: Date) => {
     .toLocaleDateString()
     .split('.')
     .filter((date) => date.length !== 0)
-    .slice(2);
+    .slice(1);
 
-  return endDate.join();
+  return endDate.join('').trim();
 };
 
 export const updateWeek = () => {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #285 

## ✅ 작업 내용

- [x] 그룹 신청현황 모달 > 승인받은 사람 수 한 명 적게 나오는 부분 수정
- [x] 알림 모달 > 새로운 알림 내용 선택 시 잘못된 주소를 거쳤다가 제대로 된 주소로 라우팅되는 부분 수정
- [x] 알림 모달 > 활동 종료 그룹 관련 내용이 잘못된 주소로 라우팅되는 부분 수정
- [x] 팔로잉 현황 > 한 주의 날짜 표시하는 부분 수정
- [x] 팔로잉 현황 > 추천 툴팁 위치 안 맞는 부분 수정

## 📸 스크린샷 / GIF / Link
<img width="1562" alt="스크린샷 2024-11-06 오후 2 52 46" src="https://github.com/user-attachments/assets/77c6bb32-05de-4574-bdde-a5a371b06814">

## 📌 이슈 사항
### 1️⃣ 그룹 신청현황 모달 > 승인받은 사람 수 한 명 적게 나오는 부분 수정
- 기존에는 승인받은 사람 수에 그룹장도 포함이 되어있어서, 서버에서 `받아온 승인받은 사람 수 - 1`의 값을 띄워주고 있었어요.
- 이제는 승인받은 사람 수에 그룹장이 포함되어있지 않은 값이 들어오고 있어서 기존 코드대로 하니까 실제와 다른 숫자를 띄워주게 되더라구요!
그래서 이 부분은 서버에서 받아온 값 그대로를 띄워주는 방식으로 수정했어요. (스크린샷 첨부)

<br />

### 2️⃣ 알림 모달 > 새로운 알림 내용 선택 시 잘못된 주소를 거쳤다가 제대로 된 주소로 라우팅되는 부분 수정
- 기존에 정의된 코드에서는 정상적인 url로 접근하기 전 잘못된 주소를 거치기 때문에, 새로운 알림을 클릭했을 때 화면 깜빡임과 뒤로가기를 실행했을 때 잘못된 주소로 접근했다는 에러가 발생했어요.
   - 화면 깜빡임 발생 이유: 잘못된 주소로 접근 -> 빈 화면 띄워줌 -> 정상적인 주소로 라우팅 -> 실제 데이터 띄워줌 -> 이 과정에서 깜빡임이 있는 것`처럼` 느껴짐 
   (사실은 잘못된 주소를 거쳐가는 과정)
   - 뒤로 가기 실행 시 잘못된 주소로 접근했다는 에러 발생 이유: 정상적인 주소 -> 뒤로가기 -> 잘못된 주소로 접근하기 때문 
   (위에서 이야기한 것러럼, 정상적인 주소로 접근하기 위해 반드시 잘못된 주소를 거쳐가기 때문에 뒤로가기를 실행했을 때는 이전 루트인 잘못된 주소로 갈 수 밖에 없음)

- **해결 방법**
   - 앞서 정의된 잘못된 주소로 향하는 navigate 코드를 모두 삭제
   - 그룹/ 팔로워 id가 변경되었을 때 최신 데이터를 불러오도록 하기 위해 react-query querykey에 그룹/ 팔로워 id 추가
   - 그룹/ 팔로워 id가 변경되었을 때 최신 데이터를 불러옴 

<br />

### 3️⃣ 알림 모달 > 활동 종료 그룹 관련 내용이 잘못된 주소로 라우팅되는 부분 수정
- 활동 종료 그룹 관련 알림을 클릭했을 때 잘못된 주소로 라우팅되고 있어서, 원래 계획한 로직대로 내 그룹 페이지로 이동하게 수정했습니다.