### PR TITLE
[ Hotfix ] 변경된 로직 반영 + 새롭게 발견한 이슈 수정

### DIFF
--- a/src/common/CommonUserList.tsx
+++ b/src/common/CommonUserList.tsx
@@ -296,9 +296,7 @@ const CommonUserList = ({
         />
       </PageNationBar>
 
-      {!isLoading && !isAdmin && users.length === 0 && (
-        <FollowerRecommendCard />
-      )}
+      {!isLoading && !isAdmin && <FollowerRecommendCard />}
 
       {errModalOn && (
         <ErrorModal

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -45,7 +45,10 @@ const ListFilter = ({
               date={{ clickedYear: year, clickedMonth: month }}
               unsolvedMonths={months}
               handleClickPrevBtn={() => handleClickPrevBtn(false)}
-              handleClickMonth={handleClickMonth}
+              handleClickMonth={(e) => {
+                handleClickMonth(e);
+                handleClickDateFilter();
+              }}
               handleClickNextBtn={() => handleClickNextBtn(false)}
             />
           </>

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -8,6 +8,7 @@ import { ListFilterProps } from '../../types/Solution/solutionTypes';
 import Calendar from './Calendar';
 
 const ListFilter = ({
+  followerId,
   sorting,
   year,
   month,
@@ -16,8 +17,7 @@ const ListFilter = ({
   handleClickMonth,
   handleClickNextBtn,
 }: ListFilterProps) => {
-  const { unsolvedData } = useGetUnsolvedMonths(year);
-
+  const { unsolvedData } = useGetUnsolvedMonths({ year, followerId });
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
   const unsolvedMonths = useRef<Array<number>>([]);
 

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -3,26 +3,19 @@ import styled, { css } from 'styled-components';
 
 import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
 import { OLD_AND_NEW } from '../../constants/Follower/currentConst';
-import useGetUnsolvedMonths from '../../libs/hooks/Solution/useGetUnsolvedMonths';
 import { ListFilterProps } from '../../types/Solution/solutionTypes';
 import Calendar from './Calendar';
 
 const ListFilter = ({
-  followerId,
   sorting,
   year,
   month,
+  unsolvedMonths,
   handleClickSorting,
   handleClickPrevBtn,
   handleClickMonth,
   handleClickNextBtn,
 }: ListFilterProps) => {
-  const { unsolvedData, isLoading } = useGetUnsolvedMonths({
-    year,
-    followerId,
-  });
-  const { months } = !isLoading && unsolvedData.data;
-
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 
   const handleClickDateFilter = () => {
@@ -43,7 +36,7 @@ const ListFilter = ({
             <IcArrowTopWhite onClick={handleClickDateFilter} />
             <Calendar
               date={{ clickedYear: year, clickedMonth: month }}
-              unsolvedMonths={months}
+              unsolvedMonths={unsolvedMonths}
               handleClickPrevBtn={() => handleClickPrevBtn(false)}
               handleClickMonth={(e) => {
                 handleClickMonth(e);

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { IcArrowBottomWhite, IcArrowTopWhite, IcCalendar } from '../../assets';
@@ -17,24 +17,17 @@ const ListFilter = ({
   handleClickMonth,
   handleClickNextBtn,
 }: ListFilterProps) => {
-  const { unsolvedData } = useGetUnsolvedMonths({ year, followerId });
+  const { unsolvedData, isLoading } = useGetUnsolvedMonths({
+    year,
+    followerId,
+  });
+  const { months } = !isLoading && unsolvedData.data;
+
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
-  const unsolvedMonths = useRef<Array<number>>([]);
 
   const handleClickDateFilter = () => {
     setIsCalendarClicked(!isCalendarClicked);
   };
-
-  const getUnsolvedMonthsArr = () => {
-    if (unsolvedData) {
-      const { months } = unsolvedData.data;
-      unsolvedMonths.current = months;
-    }
-  };
-
-  useEffect(() => {
-    getUnsolvedMonthsArr();
-  }, [unsolvedData]);
 
   return (
     <FilteredContainer>
@@ -50,7 +43,7 @@ const ListFilter = ({
             <IcArrowTopWhite onClick={handleClickDateFilter} />
             <Calendar
               date={{ clickedYear: year, clickedMonth: month }}
-              unsolvedMonths={unsolvedMonths.current}
+              unsolvedMonths={months}
               handleClickPrevBtn={() => handleClickPrevBtn(false)}
               handleClickMonth={handleClickMonth}
               handleClickNextBtn={() => handleClickNextBtn(false)}

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -146,7 +146,7 @@ const SavedSolutionList = ({
                 return (
                   <PageNumber
                     key={page}
-                    $isClicked={clickedPage === page}
+                    $isClicked={clickedPage === page && totalPage > 0}
                     onClick={() => handleClickValue({ value: page })}
                   >
                     {page}

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
 import useGetRecentFollowerRecords from '../../libs/hooks/Follower/useGetRecentFollowerRecords';
 import useGetMonthlySolution from '../../libs/hooks/Solution/useGetMonthlySolution';
+import useGetUnsolvedMonths from '../../libs/hooks/Solution/useGetUnsolvedMonths';
 import {
   ClickedValueProps,
   recordType,
@@ -21,14 +22,28 @@ const SavedSolutionList = ({
   const isFollowerMode = myId && userId.toString() !== myId;
   const followerId = isFollowerMode ? userId : undefined;
 
-  const YEAR = new Date().getFullYear();
-  const MONTH = new Date().getMonth() + 1;
+  const currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth() + 1;
+  const { unsolvedData, isLoading: isUnsolvedDataLoading } =
+    useGetUnsolvedMonths({
+      year: currentYear,
+      followerId,
+    });
+  const { months: unsolvedMonths } =
+    !isUnsolvedDataLoading && unsolvedData.data;
+
+  const monthCalendar = Array.from({ length: 12 }, (_, idx) => idx + 1);
+  const solvedMonths =
+    !isUnsolvedDataLoading &&
+    monthCalendar.filter((month) => !unsolvedMonths.includes(month));
+  const recentSolvedMonth =
+    !isUnsolvedDataLoading && solvedMonths && Math.max(...solvedMonths);
 
   const [sorting, setSorting] = useState('최신순');
   const [clickedPage, setClickedPage] = useState(1);
   const [selectedDate, setSelectedDate] = useState({
-    year: YEAR,
-    month: MONTH,
+    year: currentYear,
+    month: isFollowerMode ? recentSolvedMonth : currentMonth,
   });
 
   const { year, month } = selectedDate;
@@ -55,7 +70,6 @@ const SavedSolutionList = ({
   ) => {
     const { innerHTML } = e.currentTarget;
     setSorting(innerHTML);
-    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
   };
 
   const handleClickPrevBtn = (isPage: boolean) => {
@@ -116,10 +130,10 @@ const SavedSolutionList = ({
         <>
           {!isSmallList && (
             <ListFilter
-              followerId={followerId}
               sorting={sorting}
               year={year}
               month={month}
+              unsolvedMonths={unsolvedMonths}
               handleClickSorting={handleClickSorting}
               handleClickPrevBtn={handleClickPrevBtn}
               handleClickMonth={handleClickValue}

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -17,7 +17,6 @@ const SavedSolutionList = ({
   isSmallList,
   handleDisabledMoreBtn,
 }: SavedSolutionListProps) => {
-  const savedPage = sessionStorage.getItem('savedPage');
   const myId = sessionStorage.getItem('user');
   const isFollowerMode = myId && userId.toString() !== myId;
   const followerId = isFollowerMode ? userId : undefined;
@@ -26,16 +25,13 @@ const SavedSolutionList = ({
   const MONTH = new Date().getMonth() + 1;
 
   const [sorting, setSorting] = useState('최신순');
-  const [clickedPage, setClickedPage] = useState(
-    savedPage ? parseInt(savedPage) : 1
-  );
+  const [clickedPage, setClickedPage] = useState(1);
   const [selectedDate, setSelectedDate] = useState({
     year: YEAR,
     month: MONTH,
   });
 
   const { year, month } = selectedDate;
-
   const { data, isLoading } = isSmallList
     ? useGetRecentFollowerRecords({ userId })
     : useGetMonthlySolution({
@@ -50,7 +46,7 @@ const SavedSolutionList = ({
   const recordsArr =
     !isLoading && (records.length > 5 ? records.slice(0, 5) : records);
   const pages = Array.from(
-    { length: totalPage ? totalPage : 0 },
+    { length: totalPage ? totalPage : 1 },
     (_, idx) => idx + 1
   );
 
@@ -63,12 +59,16 @@ const SavedSolutionList = ({
   };
 
   const handleClickPrevBtn = (isPage: boolean) => {
-    isPage
-      ? setClickedPage((prev) => prev - 1)
-      : setSelectedDate({
-          ...selectedDate,
-          year: year - 1,
-        });
+    if (isPage) {
+      setClickedPage((prev) => prev - 1);
+    } else {
+      setSelectedDate({
+        ...selectedDate,
+        year: year - 1,
+      });
+      setClickedPage(1);
+    }
+
     removeSavedPage();
   };
 
@@ -82,6 +82,7 @@ const SavedSolutionList = ({
           ...selectedDate,
           month: clickedMonth,
         });
+        setClickedPage(1);
       }
     }
 
@@ -89,12 +90,16 @@ const SavedSolutionList = ({
   };
 
   const handleClickNextBtn = (isPage: boolean) => {
-    isPage
-      ? setClickedPage((prev) => prev + 1)
-      : setSelectedDate({
-          ...selectedDate,
-          year: year + 1,
-        });
+    if (isPage) {
+      setClickedPage((prev) => prev + 1);
+    } else {
+      setSelectedDate({
+        ...selectedDate,
+        year: year + 1,
+      });
+      setClickedPage(1);
+    }
+
     removeSavedPage();
   };
 

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -116,6 +116,7 @@ const SavedSolutionList = ({
         <>
           {!isSmallList && (
             <ListFilter
+              followerId={followerId}
               sorting={sorting}
               year={year}
               month={month}

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
+import useGetRecentFollowerRecords from '../../libs/hooks/Follower/useGetRecentFollowerRecords';
 import useGetMonthlySolution from '../../libs/hooks/Solution/useGetMonthlySolution';
 import {
   ClickedValueProps,
@@ -56,14 +57,15 @@ const SavedSolutionList = ({
 
   const { year, month } = selectedDate;
 
-  const { data } = useGetMonthlySolution({
-    userId: userId,
-    sortType: sorting,
-    year: year,
-    month: month,
-    page: clickedPage - 1,
-    isSmallList: isSmallList,
-  });
+  const { data } = isSmallList
+    ? useGetRecentFollowerRecords({ userId })
+    : useGetMonthlySolution({
+        userId: userId,
+        sortType: sorting,
+        year: year,
+        month: month,
+        page: clickedPage - 1,
+      });
 
   const updateTotalPage = async ({ data }: UpdateTotalPageProps) => {
     if (data) {
@@ -77,7 +79,9 @@ const SavedSolutionList = ({
       const { records } = data.data;
 
       if (records.length) {
-        setSavedRecords(records);
+        isSmallList
+          ? setSavedRecords(records.slice(0, 5))
+          : setSavedRecords(records);
         handleDisabledMoreBtn && handleDisabledMoreBtn(false);
       } else {
         setSavedRecords([]);

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -26,7 +26,7 @@ const CommonCalendar = ({
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
   const year = new Date().getFullYear();
-  const { unsolvedData } = useGetUnsolvedMonths(year);
+  const { unsolvedData } = useGetUnsolvedMonths({ year });
 
   const unsolvedMonths = useRef<Array<number>>([]);
 

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -8,7 +8,8 @@ export const getMonthlySolution = async ({
   page,
   sortType,
 }: getMonthlySolutionProps) => {
-  const formatMonth = month < 10 ? `0${month}` : `${month}`;
+  const isCorrectMonth = typeof month === 'number';
+  const formatMonth = isCorrectMonth && (month < 10 ? `0${month}` : `${month}`);
   const { data } = await api.get(
     `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=7`
   );

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -7,11 +7,10 @@ export const getMonthlySolution = async ({
   month,
   page,
   sortType,
-  isSmallList,
 }: getMonthlySolutionProps) => {
   const formatMonth = month < 10 ? `0${month}` : `${month}`;
   const { data } = await api.get(
-    `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=${isSmallList ? 5 : 7}`
+    `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=7`
   );
 
   return data;

--- a/src/libs/apis/Solution/getUnsolvedMonths.ts
+++ b/src/libs/apis/Solution/getUnsolvedMonths.ts
@@ -1,7 +1,13 @@
 import { api } from '../../api';
 
-export const getUnsolvedMonths = async (year: number) => {
-  const userId = sessionStorage.getItem('user');
+export const getUnsolvedMonths = async ({
+  year,
+  followerId,
+}: {
+  year: number;
+  followerId?: number;
+}) => {
+  const userId = followerId ? followerId : sessionStorage.getItem('user');
 
   const { data } = await api.get(
     `/records/${userId}/unsolved-months?pivotDate=${year}-01-01`

--- a/src/libs/hooks/Solution/useGetMonthlySolution.ts
+++ b/src/libs/hooks/Solution/useGetMonthlySolution.ts
@@ -8,7 +8,6 @@ const useGetMonthlySolution = ({
   month,
   page,
   sortType,
-  isSmallList,
 }: getMonthlySolutionProps) => {
   const { data } = useQuery({
     // 어떤 값이 바뀔 때마다 queryFn이 실행되었으면 좋겠다 -> queryKey에 해당 값 포함시키기 !
@@ -20,7 +19,6 @@ const useGetMonthlySolution = ({
         month,
         page,
         sortType,
-        isSmallList,
       }),
   });
 

--- a/src/libs/hooks/Solution/useGetMonthlySolution.ts
+++ b/src/libs/hooks/Solution/useGetMonthlySolution.ts
@@ -20,6 +20,7 @@ const useGetMonthlySolution = ({
         page,
         sortType,
       }),
+    enabled: !!month,
   });
 
   return { data, isLoading };

--- a/src/libs/hooks/Solution/useGetMonthlySolution.ts
+++ b/src/libs/hooks/Solution/useGetMonthlySolution.ts
@@ -9,7 +9,7 @@ const useGetMonthlySolution = ({
   page,
   sortType,
 }: getMonthlySolutionProps) => {
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     // 어떤 값이 바뀔 때마다 queryFn이 실행되었으면 좋겠다 -> queryKey에 해당 값 포함시키기 !
     queryKey: ['get-monthly-solution', year, month, page, sortType, userId],
     queryFn: async () =>
@@ -22,7 +22,7 @@ const useGetMonthlySolution = ({
       }),
   });
 
-  return { data };
+  return { data, isLoading };
 };
 
 export default useGetMonthlySolution;

--- a/src/libs/hooks/Solution/useGetUnsolvedMonths.ts
+++ b/src/libs/hooks/Solution/useGetUnsolvedMonths.ts
@@ -1,13 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUnsolvedMonths } from '../../apis/Solution/getUnsolvedMonths';
 
-const useGetUnsolvedMonths = (year: number) => {
-  const { data } = useQuery({
-    queryKey: ['get-unsolved-months', year],
-    queryFn: async () => await getUnsolvedMonths(year),
+const useGetUnsolvedMonths = ({
+  year,
+  followerId,
+}: {
+  year: number;
+  followerId?: number;
+}) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['get-unsolved-months', year, followerId],
+    queryFn: async () => await getUnsolvedMonths({ year, followerId }),
   });
 
-  return { unsolvedData: data };
+  return { unsolvedData: data, isLoading };
 };
 
 export default useGetUnsolvedMonths;

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -19,16 +19,24 @@ export interface SolutionHeaderTopProps {
   paintedStarArr: Array<number>;
 }
 
+export interface SavedSolutionListProps {
+  userId: number;
+  isSmallList: boolean;
+  handleDisabledMoreBtn?: (value: boolean) => void;
+}
+
+export interface recordType {
+  recordId: number;
+  title: string;
+  level: number;
+  tags: Array<string>;
+  platform: string;
+  problemUrl: string;
+  createdAt: string;
+}
+
 export interface SavedSolutionProps {
-  record: {
-    recordId: number;
-    title: string;
-    level: number;
-    tags: Array<string>;
-    platform: string;
-    problemUrl: string;
-    createdAt: string;
-  };
+  record: recordType;
   followerId?: number;
   clickedPage?: number;
   isModal?: boolean;

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -113,6 +113,5 @@ export interface getMonthlySolutionProps {
   year: number;
   month: number;
   page: number;
-  isSmallList: boolean;
   sortType?: string;
 }

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -50,7 +50,7 @@ export interface LevelProps {
 export interface CalendarProps {
   date: {
     clickedYear: number;
-    clickedMonth: number;
+    clickedMonth: number | boolean;
   };
   unsolvedMonths: Array<number>;
   handleClickPrevBtn: () => void;
@@ -105,10 +105,10 @@ export interface ClickedValueProps {
 }
 
 export interface ListFilterProps {
-  followerId?: number;
   sorting: string;
   year: number;
-  month: number;
+  month: number | boolean;
+  unsolvedMonths: Array<number>;
   handleClickSorting: (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => void;
@@ -120,7 +120,7 @@ export interface ListFilterProps {
 export interface getMonthlySolutionProps {
   userId: number;
   year: number;
-  month: number;
+  month: number | boolean;
   page: number;
   sortType?: string;
 }

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -105,6 +105,7 @@ export interface ClickedValueProps {
 }
 
 export interface ListFilterProps {
+  followerId?: number;
   sorting: string;
   year: number;
   month: number;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #288 

## ✅ 작업 내용

- [x] 팔로잉 수와 관계없이, 추천 카드가 보이도록 수정
- [x] 팔로워 개인 페이지에서 문제풀이를 보여주는 경우, 최근 푼 5문제를 보여주도록 수정 (기존: 한 달간 푼 5문제를 보여줌)
- [x] 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 선택한 달이 바뀌어도 이전에 선택한 달에서 클릭한 페이지가 그대로 유지되는 이슈 해결
- [x] 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 문제풀이 데이터가 없는 경우, 페이지네이션이 불안정한 이슈 해결
- [x] 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 유저에 따라 문제풀이를 한/ 하지 않은 달 정보가 제대로 불러와지지 않는 이슈 해결
- [x] 팔로워 개인 페이지 > 전체 푼 문제 수가 5개를 넘는 경우에만 더보기 버튼이 활성화되도록 조건 추가
- [x] 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 현재 속한 달이 아닌, 가장 최근 문제 푼 달이 우선으로 보여지도록 수정

## 📸 스크린샷 / GIF / Link


https://github.com/user-attachments/assets/494d0d84-0249-4ef0-8d49-1628e5a17c56

![image](https://github.com/user-attachments/assets/2250629e-967e-41c9-ae98-adda3756caea)


## 📌 이슈 사항
### 1️⃣ 변경된 로직 반영

1. 팔로잉 수와 관계없이, 추천 카드가 보이도록 수정
    - 기존에 있었던 `users.length === 0`이라는 조건을 삭제하여 팔로워 수와 관계없이 모든 팔로워 뷰에 추천 컴포넌트가 뜨도록 구현했어요.
2. 팔로워 개인 페이지에서 문제풀이를 보여주는 경우, 최근 푼 5문제를 보여주도록 수정
    - 기존에는 현재 속한 달의 최근 푼 5문제를 보여줬는데, 디자이너 측 요청에 따라 팔로워가 푼 전체 문제 중 5문제를 보여주도록 수정했어요.

<br />

### 2️⃣ 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 페이지네이션 관련 이슈

- 기존 페이지네이션 관련 로직이 꼬여있음을 알게 되어서 복잡한 로직을 간단하게 풀었어요.
- 페이지네이션 초기 값을 1로 수정하여 문제풀이가 없는 경우에도 현재 페이지에 1이라는 숫자가 떠있도록 수정했어요.

<br />

### 3️⃣ 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 유저에 따라 문제풀이를 한/ 하지 않은 달 정보가 제대로 불러와지지 않는 이슈

- 현재 접근한 팔로워 뷰의 유저가 푼 문제와 관계없이 일정하게 9, 10월만 활성화되어 있는 것을 알게 되었어요.
- 코드를 뜯어보니 문제풀이를 하지 않은 달을 불러오는 api에서 userId를 현재 접속한 유저의 id(본인의 userId)로 제한하고 있어, 팔로워 뷰에 접근하더라도 본인의 문제풀이 현황이 반영되고 있었어요.
- 이를 해결하기 위해서 팔로워 뷰에서 접근한 경우, followerId라는 nullable한 Props를 내려주어 해당 id에 맞는 정보를 가져오되 본인의 문제풀이 정보를 가져오는 로직에는 영향이 가지 않도록 수정했어요.

<br />

### 4️⃣ 팔로워 개인 페이지 > 전체 문제풀이 뷰 > 현재 속한 달이 아닌, 가장 최근 문제 푼 달이 우선으로 보여지도록 수정

- 단체 방에서도 언급한 것처럼 팔로워 개인 페이지의 전체 문제풀이 뷰에서는 항상 현재 날짜가 속한 달의 문제풀이 리스트를 보여주고 있었어요.
- 만약 해당 달에 푼 문제가 없는 경우, 유저는 빈 화면을 가장 먼저 마주하게 되는데 이 부분이 개인적으로 너무 어색하다는 생각이 들더라구요.
(+ 문제풀이가 없는 달은 다시 선택할 수 없는데, 이러한 화면을 첫 화면으로 보여주는게 사용자 경험에 결코 좋지 않을 것 같다는 생각)
- 가장 최근 문제 푼 달이 기준이 된다면 더 자연스러운 플로우가 나올 것 같아 디자이너 분들께 제안 > 반영하게 되었어요.

- **수정된 플로우**
    - 현재 년도를 기준으로 문제풀이를 하지 않은 달을 서버로부터 받아와요. (오름차순)
    - 1~12까지 들어있는 배열을 하나 만들고, 해당 배열에서 문제풀이 하지 않은 달과 동일한 숫자를 지워요. (오름차순)
    - 배열에 남은 숫자 중 가장 큰 숫자를 현재 유저의 가장 최근 문제풀이 달로 인지하고, 이 달을 기준으로 문제풀이 리스트를 가져와요.