### PR TITLE
[ Hotfix ] 랜딩페이지 라우팅 및 디자인 QA 반영

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -11,7 +11,6 @@ import GroupEdit from './page/GroupEdit';
 import GroupJoin from './page/GroupJoin';
 import GroupMemberPage from './page/GroupMemberPage';
 import Home from './page/Home';
-import LandingPage from './page/LandingPage';
 import LoginLoadingPage from './page/LoginLoadingPage';
 import LoginPage from './page/LoginPage';
 import MyGroup from './page/MyGroup';
@@ -47,7 +46,6 @@ const Router = () => {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/group-all" element={<GroupAllPage />} />
         <Route path="/group/:id/edit" element={<GroupEdit />} />
-        <Route path="/landing" element={<LandingPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -78,7 +78,7 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
       onMouseLeave={() => handleOpenAlarm(false)}
     >
       <HeaderContainer onMouseLeave={() => handleOpenGnb(false)}>
-        <LogoContainer onClick={() => navigate('/')}>
+        <LogoContainer onClick={() => isLoginSuccess && navigate('/')}>
           <IcLogo />
         </LogoContainer>
         <NavBarContainer>

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -139,10 +139,12 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
         <IcArrowContainer
           onClick={() => isLoginSuccess && handleOpenGnb(true, 'profile')} // 클릭 시 Gnb 토글
         >
-          {isLoginSuccess && isGnbOpen && isHoveredProfile && (
+          {isLoginSuccess && (
             <>
               <IcArrowBottomWhite />
-              <Gnb category="profile" handleOpenGnb={handleOpenGnb} />
+              {isGnbOpen && isHoveredProfile && (
+                <Gnb category="profile" handleOpenGnb={handleOpenGnb} />
+              )}
             </>
           )}
         </IcArrowContainer>

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -126,9 +126,11 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
         <IcArrowContainer
           onClick={() => isLoginSuccess && handleOpenGnb(true, 'profile')} // 클릭 시 Gnb 토글
         >
-          <IcArrowBottomWhite />
           {isLoginSuccess && isGnbOpen && isHoveredProfile && (
-            <Gnb category="profile" handleOpenGnb={handleOpenGnb} />
+            <>
+              <IcArrowBottomWhite />
+              <Gnb category="profile" handleOpenGnb={handleOpenGnb} />
+            </>
           )}
         </IcArrowContainer>
       </HeaderContainer>

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -50,12 +50,14 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   };
 
   useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 0);
-    window.addEventListener('scroll', handleScroll);
+    if (!isLoginSuccess) {
+      const handleScroll = () => setIsScrolled(window.scrollY > 0);
+      window.addEventListener('scroll', handleScroll);
 
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    } else setIsScrolled(true);
   }, []);
 
   useEffect(() => {

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -25,6 +25,7 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
       (data: { isRead: boolean }) => data.isRead === false
     ) || [];
 
+  const [isScrolled, setIsScrolled] = useState(false);
   const [hoveredCategory, setHoveredCategory] = useState('');
   const [isGnbOpen, setIsGnbOpen] = useState(false);
   const [isAlarmOpen, setIsAlarmOpen] = useState(false);
@@ -49,6 +50,15 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   };
 
   useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 0);
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
     if (newAlarms.length > 0) {
       sessionStorage.setItem('isNewAlarmExit', 'true');
       setIsNewAlarmExit(true);
@@ -61,7 +71,10 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
   // HeaderContainer 에 Leave 있는 이유는 Gnb 컨텐츠 부분을 꼭 지나치고 마우스를 나가야만 창이 닫혀서
   // 컨텐츠 부분을 지나치지 않더라도 바로 창이 닫히게끔 하기 위해 추가함
   return (
-    <HeaderWrapper onMouseLeave={() => handleOpenAlarm(false)}>
+    <HeaderWrapper
+      $isColorBg={isScrolled}
+      onMouseLeave={() => handleOpenAlarm(false)}
+    >
       <HeaderContainer onMouseLeave={() => handleOpenGnb(false)}>
         <LogoContainer onClick={() => navigate('/')}>
           <IcLogo />
@@ -140,7 +153,7 @@ const Header = ({ clickedCategory, handleClickCategory }: HeaderProps) => {
 
 export default Header;
 
-const HeaderWrapper = styled.header`
+const HeaderWrapper = styled.header<{ $isColorBg: boolean }>`
   display: flex;
   justify-content: center;
   position: fixed;
@@ -149,7 +162,8 @@ const HeaderWrapper = styled.header`
 
   width: 100%;
 
-  background-color: ${({ theme }) => theme.colors.gray900};
+  background-color: ${({ $isColorBg, theme }) =>
+    $isColorBg ? theme.colors.gray900 : 'transparent'};
 `;
 
 const HeaderContainer = styled.div`

--- a/src/components/Landing/Landing1.tsx
+++ b/src/components/Landing/Landing1.tsx
@@ -2,25 +2,20 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { ImgLanding, LandingMoon } from '../../assets';
-import PageLayout from '../PageLayout/PageLayout';
 
 const Landing1 = () => {
   const navigate = useNavigate();
 
   return (
-    <PageLayout category="홈">
-      <LoginContainer>
-        <TitleContainer>
-          <Text>이번 코딩테스트는 합격하자!</Text>
-          <Title>코딩테스트 100번 이상 본 개발자들이</Title>
-          <Title>사용하려고 만든 서비스</Title>
-        </TitleContainer>
-        <HomeBtn onClick={() => navigate('/login')}>
-          지금 무료로 시작하기
-        </HomeBtn>
-        <img src={LandingMoon} alt="랜딩페이지"></img>
-      </LoginContainer>
-    </PageLayout>
+    <LoginContainer>
+      <TitleContainer>
+        <Text>이번 코딩테스트는 합격하자!</Text>
+        <Title>코딩테스트 100번 이상 본 개발자들이</Title>
+        <Title>사용하려고 만든 서비스</Title>
+      </TitleContainer>
+      <HomeBtn onClick={() => navigate('/login')}>지금 무료로 시작하기</HomeBtn>
+      <img src={LandingMoon} alt="랜딩페이지"></img>
+    </LoginContainer>
   );
 };
 
@@ -31,6 +26,7 @@ const LoginContainer = styled.div`
 
   width: 100%;
   height: 100vh;
+  padding-top: 11.6rem;
   margin: 0 auto;
 
   background-size: cover;

--- a/src/components/Landing/Landing1.tsx
+++ b/src/components/Landing/Landing1.tsx
@@ -15,7 +15,9 @@ const Landing1 = () => {
           <Title>코딩테스트 100번 이상 본 개발자들이</Title>
           <Title>사용하려고 만든 서비스</Title>
         </TitleContainer>
-        <HomeBtn onClick={() => navigate('/')}>지금 무료로 시작하기</HomeBtn>
+        <HomeBtn onClick={() => navigate('/login')}>
+          지금 무료로 시작하기
+        </HomeBtn>
         <img src={LandingMoon} alt="랜딩페이지"></img>
       </LoginContainer>
     </PageLayout>

--- a/src/components/Landing/Landing11.tsx
+++ b/src/components/Landing/Landing11.tsx
@@ -13,7 +13,7 @@ const Landing11 = () => {
         <div>
           <IcLoginBig />
         </div>
-        <HomeBtn onClick={() => navigate('/')}>
+        <HomeBtn onClick={() => navigate('/login')}>
           깃허브로 3초만에 가입하기
         </HomeBtn>
       </TitleContainer>

--- a/src/components/Landing/Landing4.tsx
+++ b/src/components/Landing/Landing4.tsx
@@ -1,10 +1,9 @@
-import { forwardRef } from 'react';
 import styled from 'styled-components';
 import { ImgLanding4Bg, LandingGithubInfoImg } from '../../assets';
 
-const Landing4 = forwardRef<HTMLDivElement>((_, ref) => {
+const Landing4 = () => {
   return (
-    <Landing4Container ref={ref}>
+    <Landing4Container id="Landing4">
       <LandingTop>
         <Info>깃허브와의 연동</Info>
         <TitleContainer>
@@ -24,7 +23,7 @@ const Landing4 = forwardRef<HTMLDivElement>((_, ref) => {
       </LandingImgContainer>
     </Landing4Container>
   );
-});
+};
 
 const Landing4Container = styled.article`
   width: 100%;

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import Header from '../../common/Header';
 import { PageLayoutProps } from '../../types/PageLayout/PageLayoutType';
 import { movePagePosition } from '../../utils/movePagePosition';
 
 const PageLayout = ({ category, children }: PageLayoutProps) => {
   const navigate = useNavigate();
+  const nickname = sessionStorage.getItem('nickname');
+  const profileImg = sessionStorage.getItem('profileImg');
+  const language = sessionStorage.getItem('language');
+  // isLoginSuccess를 불린 값으로 정의
+  const isLoginSuccess = !!(nickname && profileImg && language !== '사용언어');
   const [clickedCategory, setClickedCategory] = useState(category);
 
   const handleEarlyNavigate = (clickedNav: string) => {
@@ -35,7 +40,7 @@ const PageLayout = ({ category, children }: PageLayoutProps) => {
   }, []);
 
   return (
-    <PageLayoutContainer>
+    <PageLayoutContainer $isNotLandingPage={isLoginSuccess}>
       <Header
         clickedCategory={clickedCategory}
         handleClickCategory={handleClickCategory}
@@ -47,12 +52,16 @@ const PageLayout = ({ category, children }: PageLayoutProps) => {
 
 export default PageLayout;
 
-const PageLayoutContainer = styled.div`
+const PageLayoutContainer = styled.div<{ $isNotLandingPage: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
 
   width: 100%;
-  padding-top: 11.5rem;
+  ${({ $isNotLandingPage }) =>
+    $isNotLandingPage &&
+    css`
+      padding-top: 11.5rem;
+    `};
 `;

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -54,4 +54,5 @@ const PageLayoutContainer = styled.div`
   flex-direction: column;
 
   width: 100%;
+  padding-top: 11.5rem;
 `;

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -18,7 +18,7 @@ const PageLayout = ({ category, children }: PageLayoutProps) => {
       case '그룹':
         return navigate('/group');
       default:
-        return navigate('/');
+        return navigate('/login');
     }
   };
 

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -54,5 +54,4 @@ const PageLayoutContainer = styled.div`
   flex-direction: column;
 
   width: 100%;
-  padding-top: 11.5rem;
 `;

--- a/src/libs/hooks/SSE/useDeleteNotification.ts
+++ b/src/libs/hooks/SSE/useDeleteNotification.ts
@@ -8,7 +8,7 @@ const useDeleteNotification = () => {
     mutationFn: async () => await deleteNotification(),
     onSuccess: () => {
       sessionStorage.clear();
-      navigate('/');
+      navigate('/login');
     },
     onError: (err) => console.log(err),
   });

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -17,7 +17,9 @@ const Home = () => {
 
   useEffect(() => {
     if (!user || isNotRegisted) {
-      !user ? navigate('/login') : navigate('/register');
+      !user
+        ? navigate('/login', { state: { isLandingActive: true } })
+        : navigate('/register');
     }
     return;
   });

--- a/src/page/LandingPage.tsx
+++ b/src/page/LandingPage.tsx
@@ -9,7 +9,6 @@ import Landing6 from '../components/Landing/Landing6';
 import Landing7 from '../components/Landing/Landing7';
 import Landing8 from '../components/Landing/Landing8';
 import Landing9 from '../components/Landing/Landing9';
-import PageLayout from '../components/PageLayout/PageLayout';
 
 const LandingPage = () => {
   const scrollToLanding4 = () => {
@@ -23,7 +22,7 @@ const LandingPage = () => {
   };
 
   return (
-    <PageLayout category="랜딩페이지">
+    <>
       <Landing1 />
       <Landing2 />
       <Landing3 scrollToLanding4={scrollToLanding4} />
@@ -35,7 +34,7 @@ const LandingPage = () => {
       <Landing9 />
       <Landing10 />
       <Landing11 />
-    </PageLayout>
+    </>
   );
 };
 

--- a/src/page/LandingPage.tsx
+++ b/src/page/LandingPage.tsx
@@ -10,6 +10,7 @@ import Landing6 from '../components/Landing/Landing6';
 import Landing7 from '../components/Landing/Landing7';
 import Landing8 from '../components/Landing/Landing8';
 import Landing9 from '../components/Landing/Landing9';
+import PageLayout from '../components/PageLayout/PageLayout';
 
 const LandingPage = () => {
   const landing4Ref = useRef<HTMLDivElement>(null);
@@ -19,7 +20,7 @@ const LandingPage = () => {
   };
 
   return (
-    <>
+    <PageLayout category="랜딩페이지">
       <Landing1 />
       <Landing2 />
       <Landing3 scrollToLanding4={scrollToLanding4} />
@@ -31,7 +32,7 @@ const LandingPage = () => {
       <Landing9 />
       <Landing10 />
       <Landing11 />
-    </>
+    </PageLayout>
   );
 };
 

--- a/src/page/LandingPage.tsx
+++ b/src/page/LandingPage.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import Landing1 from '../components/Landing/Landing1';
 import Landing10 from '../components/Landing/Landing10';
 import Landing11 from '../components/Landing/Landing11';
@@ -13,10 +12,14 @@ import Landing9 from '../components/Landing/Landing9';
 import PageLayout from '../components/PageLayout/PageLayout';
 
 const LandingPage = () => {
-  const landing4Ref = useRef<HTMLDivElement>(null);
-
   const scrollToLanding4 = () => {
-    landing4Ref.current?.scrollIntoView({ behavior: 'smooth' });
+    const landing4Top = document.getElementById('Landing4')?.offsetTop;
+
+    if (landing4Top) {
+      const scrollToLanding4 = landing4Top - 100;
+
+      scrollTo({ top: scrollToLanding4, behavior: 'smooth' });
+    }
   };
 
   return (
@@ -24,7 +27,7 @@ const LandingPage = () => {
       <Landing1 />
       <Landing2 />
       <Landing3 scrollToLanding4={scrollToLanding4} />
-      <Landing4 ref={landing4Ref} />
+      <Landing4 />
       <Landing5 />
       <Landing6 />
       <Landing7 />

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 import { IcLoginBig } from '../assets';
 import LoginButton from '../components/Login/LoginButton';
 import PageLayout from '../components/PageLayout/PageLayout';
+import LandingPage from './LandingPage';
 
 const LoginPage = () => {
   const { state } = useLocation();
-  const { roomId } = state || {};
+  const { roomId, isLandingActive } = state || {};
 
   const navigate = useNavigate();
   const isAlreadyLogin =
@@ -27,15 +28,19 @@ const LoginPage = () => {
 
   return (
     <PageLayout category={isAlreadyLogin ? '홈' : 'login'}>
-      <LoginContainer>
-        <Title>성공적인 코딩테스트를 위한 최적의 경로</Title>
-        <IcLoginBig />
-        {!isAlreadyLogin || isNotResgisted ? (
-          <LoginButton onClick={onClickSocialLogin} />
-        ) : (
-          <HomeBtn onClick={() => navigate('/')}>홈으로</HomeBtn>
-        )}
-      </LoginContainer>
+      {isLandingActive ? (
+        <LandingPage />
+      ) : (
+        <LoginContainer>
+          <Title>성공적인 코딩테스트를 위한 최적의 경로</Title>
+          <IcLoginBig />
+          {!isAlreadyLogin || isNotResgisted ? (
+            <LoginButton onClick={onClickSocialLogin} />
+          ) : (
+            <HomeBtn onClick={() => navigate('/')}>홈으로</HomeBtn>
+          )}
+        </LoginContainer>
+      )}
     </PageLayout>
   );
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #293 

## ✅ 작업 내용

- [x] 랜딩페이지 라우터 수정
- [x] 3번 랜딩페이지에서 버튼 클릭 시, 4번 랜딩페이지 상단이 아닌 중간으로 이동하는 이슈 해결
- [x] 랜딩페이지에서 헤더 로고 클릭 이벤트 막고, 프로필 화살표 버튼 렌더링되지 않도록 수정
- [x] 랜딩페이지 시작 시에만 헤더 배경색이 transparent로 들어가도록 구현


## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/f3f31421-234a-4525-941e-b0746f479124

https://github.com/user-attachments/assets/b48e712b-5bbf-4240-b4a9-35b1f784e7cc


## 📌 이슈 사항
### 1️⃣ 랜딩페이지 라우터 수정
기존에 `/landing`으로 되어있던 랜딩페이지 라우터를 로그인페이지와 동일하게 들어가도록 수정했어요.

랜딩페이지에 또 다른 주소가 붙는게 어색하다는 생각이 들어서 홈화면과 동일한 주소를 넣어주고 싶었는데,
1. 랜딩페이지는 로그인하지 않은 사용자만 보는 화면이라는 점
2. 홈으로 라우팅시키더라도 로그인을 하지 않은 사용자는 결국 로그인 페이지를 가장 먼저 보게된다는 점

을 고려해서 로그인과 동일한 주소를 갖도록 구현했어요.

다만, 로그아웃을 한 경우에는 랜딩페이지를 띄우지 않기로 했기 때문에, 로그인을 하지 않은 채로 서비스에 접속하여 로그인 페이지로 라우팅되는 경우에만 Navigate state를 함께 넘겨주어 지정한 state가 들어온 경우에만 랜딩페이지 라고 인식 -> 랜딩페이지를 띄워줍니다.

<br />

### 2️⃣ 3번 랜딩페이지에서 버튼 클릭 시, 4번 랜딩페이지 상단이 아닌 중간으로 이동하는 이슈 해결
랜딩페이지를 확인해보니 3번 페이지에서 버튼을 클릭하면 4번 페이지 상단으로 이동해야 하는데, 중간 지점으로 이동하더라구요...!

이를 해결하기 위해 아래와 같은 로직을 설계했어요.
1. 4번 랜딩페이지 최상단 태그에 id를 부여
2. 해당 요소의 상단 위치 구하기
3. 3번 랜딩페이지의 버튼 클릭 시, 앞서 구한 위치보다 100만큼 적은 숫자에 해당하는 위치로 이동

<br />

### 3️⃣ 랜딩페이지 시작 시에만 헤더 배경색이 transparent로 들어가도록 구현
랜딩페이지 시작 시에만 헤더 배경색을 투명으로 적용, 이후 스크롤을 내리거나 다른 뷰에서는 기존의 색상을 유지하도록 구현했어요.
처음에는 불린 값을 하나 만들어서 1번 랜딩페이지에서만 true 값으로 설정 + 2번 랜딩페이지에서 false 값으로 설정하여 이후 랜딩페이지는 false 값을 유지 -> 해당 값에 따라 분기처리를 할까.. 도 생각해봤지만, 그렇게 하면 코드가 너무 지저분해지고 로직도 꼬인다고 느껴졌어요.

그래서 현재는 페이지 스크롤 값을 받아와서 이 값이 0인 경우 `스크롤 없음`으로 인식하여 헤더의  배경을 투명하게 하고, 양수인 경우 `스크롤을 했다`라고 인식하여 gray900의 배경색으로 바뀌도록 구현해놨어요!
로직은 아래와 같아요.
1. 로그인 여부 판별 -> 로그인하지 않은 경우에만 아래 로직 동작
2. 페이지 내부 세로 스크롤 값이 양수인 경우, 스크롤을 했음으로 간주
3. `isScrolled`라는 불린 값을 true로 변경
4. 로그인을 한 페이지에서는 헤더를 투명으로 변경하지 않기 때문에, 항상 isScrolled 값을 true로 유지
5. isScrolled 값이 true인 경우, gray900을 배경색으로 지정
isScrolled 값이 false인 경우, transparent를 배경색으로 지정하여 투명한 헤더 생성


PageLayout에서 padding-top이 들어가면 헤더의 배경을 투명으로 바꿔도 상위 컴포넌트의 배경색인(gray900)이 되기 때문에, PageLayout에서도 로그인 여부를 판단해서 로그인을 한 경우(투명 헤더가 필요없는 경우)에만 padding-top이 동작하도록 조건을 걸어줬어요.

이렇게 하면 Header와 PageLayout 사이 중복코드가 발생하게 되어서 이 부분이 마음에 들지는 않지만,, 해당 부분을 없애고 헤더에 props를 내려준다면 갑자기 3개의 Props가 추가되기 때문에 이것도 좋은 방법은 아니라는 생각이 들어 지금 코드를 유지했어요. 
혹시 더 좋은 의견이 있다면 피드백 부탁드립니다 !