### PR TITLE
 [ Hotfix ] GroupEdit 뷰 데이터 로딩 완료 후 초기값 이슈, ALL 태그 다른게 들어오는 부분 이슈 해결

### DIFF
--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { IcArrowBottomGray, IcArrowTopGray } from '../../assets';
 import CommonHashTag from '../../common/CommonHashTag';
-import { ALL_TAG, DUMMY } from '../../constants/GroupCreate/LanguageConst';
+import { ALL_TAG, LANGUAGE } from '../../constants/GroupCreate/LanguageConst';
 import { LanguageSectionProps } from '../../types/GroupCreate/GroupCreateType';
 
 const LanguageSection = ({
@@ -22,7 +22,7 @@ const LanguageSection = ({
     }
     if (tag === ALL_TAG) {
       setIsAllSelected(true);
-      setSelectedTags(DUMMY);
+      setSelectedTags(LANGUAGE);
     } else {
       if (!selectedTags.includes(tag)) {
         const newTags = [...selectedTags, tag];
@@ -46,7 +46,7 @@ const LanguageSection = ({
 
   const selectAllTags = () => {
     setIsAllSelected(true);
-    setSelectedTags(DUMMY);
+    setSelectedTags(LANGUAGE);
     toggleDropdown();
   };
 
@@ -97,7 +97,7 @@ const LanguageSection = ({
             {ALL_TAG}
           </DropdownItem>
           <Borderline />
-          {DUMMY.map((tag) => (
+          {LANGUAGE.map((tag) => (
             <PickTagContainer key={tag}>
               <DropdownItem
                 $isSelected={selectedTags.includes(tag)}

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -6,7 +6,7 @@ import { ALL_TAG, LANGUAGE } from '../../constants/GroupCreate/LanguageConst';
 import { LanguageSectionProps } from '../../types/GroupCreate/GroupCreateType';
 
 const LanguageSection = ({
-  selectedTags = [], // 기본 값을 빈 배열로 설정
+  selectedTags,
   setSelectedTags,
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);

--- a/src/components/GroupCreate/LanguageSection.tsx
+++ b/src/components/GroupCreate/LanguageSection.tsx
@@ -10,7 +10,9 @@ const LanguageSection = ({
   setSelectedTags,
 }: LanguageSectionProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [isAllSelected, setIsAllSelected] = useState(false);
+  const [isAllSelected, setIsAllSelected] = useState(
+    selectedTags.length === 11
+  );
 
   const toggleDropdown = () => {
     setIsDropdownOpen((prev) => !prev);

--- a/src/constants/GroupCreate/LanguageConst.tsx
+++ b/src/constants/GroupCreate/LanguageConst.tsx
@@ -1,7 +1,7 @@
-export const DUMMY = [
+export const LANGUAGE = [
   'Python',
   'Java',
-  'Javascript',
+  'JavaScript',
   'C++',
   'C',
   'C#',

--- a/src/libs/hooks/GroupEdit/usePatchRooms.ts
+++ b/src/libs/hooks/GroupEdit/usePatchRooms.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import patchRooms from './../../apis/GroupEdit/patchRooms';
 
 interface PatchRoomsProps {
@@ -9,18 +10,19 @@ interface PatchRoomsProps {
 
 const usePatchRooms = () => {
   const [errMsg, setErrMsg] = useState('');
-
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+
   const mutation = useMutation({
-    mutationFn: async ({ roomId, requestBody }: PatchRoomsProps) =>
-      // 객체 형태로 전달
-      await patchRooms(roomId, requestBody),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['get-detail'] });
+    mutationFn: ({ roomId, requestBody }: PatchRoomsProps) =>
+      patchRooms(roomId, requestBody), // await 제거
+    onSuccess: (_, { roomId }) => {
+      // roomId를 queryKey와 navigate에 사용
+      queryClient.invalidateQueries({ queryKey: ['get-detail', roomId] });
       queryClient.invalidateQueries({ queryKey: ['get-rooms-id'] });
+      navigate(`/group/${roomId}/admin`);
     },
     onError: (err: any) => {
-      // 에러 메시지 처리
       const message = err?.response?.data?.message || 'Something went wrong';
       setErrMsg(message);
     },

--- a/src/libs/hooks/GroupEdit/usePatchRooms.ts
+++ b/src/libs/hooks/GroupEdit/usePatchRooms.ts
@@ -14,8 +14,9 @@ const usePatchRooms = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: ({ roomId, requestBody }: PatchRoomsProps) =>
-      patchRooms(roomId, requestBody), // await 제거
+    mutationFn: async ({ roomId, requestBody }: PatchRoomsProps) =>
+      // 객체 형태로 전달
+      await patchRooms(roomId, requestBody),
     onSuccess: (_, { roomId }) => {
       // roomId를 queryKey와 navigate에 사용
       queryClient.invalidateQueries({ queryKey: ['get-detail', roomId] });

--- a/src/libs/hooks/GroupEdit/usePatchRooms.ts
+++ b/src/libs/hooks/GroupEdit/usePatchRooms.ts
@@ -28,7 +28,11 @@ const usePatchRooms = () => {
     },
   });
 
-  return { patchMutation: mutation.mutate, patchApproveErr: errMsg };
+  return {
+    patchMutation: mutation.mutate,
+    patchApproveErr: errMsg,
+    isPending: mutation.isPending,
+  };
 };
 
 export default usePatchRooms;

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -27,6 +27,7 @@ const GroupEdit = () => {
     introduce,
     information,
     password,
+    isPublicRoom,
   } = !isGetDetailLoading && data?.data;
 
   const initialData = {
@@ -40,12 +41,11 @@ const GroupEdit = () => {
   };
 
   const [inputs, setInputs] = useState(initialData);
-  const [isPublicGroup, setIsPublicGroup] = useState<boolean>(!password);
+  const [isPublicGroup, setIsPublicGroup] = useState<boolean>(isPublicRoom);
   const [previewImage, setPreviewImage] = useState<string | null>(imageSrc);
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>(tags);
 
-  const [savedSecretKey, setSavedSecretKey] = useState<string>(password || '');
   const navigate = useNavigate();
   const { patchMutation, isPending } = usePatchRooms();
   const { title, num, secretKey, intro, group } = inputs;
@@ -69,20 +69,6 @@ const GroupEdit = () => {
   };
 
   const handleActiveChange = (active: boolean) => {
-    if (active) {
-      // 공개 그룹 선택 시 기존 비밀번호를 임시 저장하고 비밀번호 필드 초기화
-      setSavedSecretKey(inputs.secretKey);
-      setInputs((prevInputs) => ({
-        ...prevInputs,
-        secretKey: '',
-      }));
-    } else {
-      // 비밀 그룹 선택 시 저장된 비밀번호 복원
-      setInputs((prevInputs) => ({
-        ...prevInputs,
-        secretKey: savedSecretKey,
-      }));
-    }
     setIsPublicGroup(active);
   };
 
@@ -115,7 +101,7 @@ const GroupEdit = () => {
 
     const postData = {
       title,
-      password: secretKey,
+      password: isPublicGroup ? '' : secretKey,
       capacity: num,
       tags: selectedTags,
       introduce: intro,
@@ -154,7 +140,7 @@ const GroupEdit = () => {
         previewImage: imageSrc,
         selectedTags: tags,
       });
-      /*    setIsPublicGroup(isPublicRoom); */
+      setIsPublicGroup(isPublicRoom);
       setPreviewImage(imageSrc);
       setSelectedTags(tags);
     }

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -10,8 +10,8 @@ import TitleSection from '../components/GroupCreate/TitleSection';
 import PageLayout from '../components/PageLayout/PageLayout';
 import CommonButton from './../common/CommonButton';
 
+import usePatchRooms from '../libs/hooks/GroupEdit/usePatchRooms';
 import { ALL_TAG, DUMMY } from './../constants/GroupCreate/LanguageConst';
-import patchRooms from './../libs/apis/GroupEdit/patchRooms';
 import useGetDetail from './../libs/hooks/GroupDetail/useGetDetail';
 
 const GroupEdit = () => {
@@ -40,7 +40,7 @@ const GroupEdit = () => {
   const [inputs, setInputs] = useState(initialData);
   const [isPublicGroup, setIsPublicGroup] = useState<boolean>(!password);
   const [previewImage, setPreviewImage] = useState<string | null>(
-    imageSrc || ''
+    initialData.previewImage
   );
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>(
@@ -49,6 +49,7 @@ const GroupEdit = () => {
 
   const [savedSecretKey, setSavedSecretKey] = useState<string>(password || '');
   const navigate = useNavigate();
+  const { patchMutation } = usePatchRooms();
   const { title: roomTitleInput, num, secretKey, intro, group } = inputs;
 
   const maxCharLimits: { [key: string]: number } = {
@@ -110,7 +111,7 @@ const GroupEdit = () => {
     group !== '';
 
   // 저장 버튼 클릭 시 그룹 정보 수정 API 호출
-  const handleSaveBtnClick = async () => {
+  const handleSaveBtnClick = () => {
     if (!isActive) return;
 
     const postData = {
@@ -121,6 +122,7 @@ const GroupEdit = () => {
       introduce: intro,
       information: group,
     };
+
     const requestBody = new FormData();
     const jsonChange = JSON.stringify(postData);
 
@@ -130,12 +132,7 @@ const GroupEdit = () => {
       requestBody.append('imageFile', selectedImageFile);
     }
 
-    try {
-      await patchRooms(Number(id), requestBody);
-      navigate(`/group/${id}/admin`);
-    } catch (error) {
-      console.log(error);
-    }
+    patchMutation({ roomId: Number(id), requestBody });
   };
 
   const handleCancelBtnClick = () => {

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -20,7 +20,7 @@ const GroupEdit = () => {
   const { data, isLoading: isGetDetailLoading } = useGetDetail(parseInt(id));
 
   const {
-    title: groupTitle,
+    title: originTitle,
     imageSrc,
     capacity,
     tags,
@@ -28,30 +28,27 @@ const GroupEdit = () => {
     information,
     password,
   } = !isGetDetailLoading && data?.data;
+
   const initialData = {
-    title: groupTitle || '',
-    num: capacity ? capacity.toString() : '0',
-    secretKey: password || '',
-    intro: introduce || '',
-    group: information || '',
-    previewImage: imageSrc || null,
-    selectedTags: tags || '',
+    title: '',
+    num: 0,
+    secretKey: '',
+    intro: '',
+    group: '',
+    previewImage: '',
+    selectedTags: [''],
   };
 
   const [inputs, setInputs] = useState(initialData);
   const [isPublicGroup, setIsPublicGroup] = useState<boolean>(!password);
-  const [previewImage, setPreviewImage] = useState<string | null>(
-    initialData.previewImage
-  );
+  const [previewImage, setPreviewImage] = useState<string | null>(imageSrc);
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
-  const [selectedTags, setSelectedTags] = useState<string[]>(
-    initialData.selectedTags
-  );
+  const [selectedTags, setSelectedTags] = useState<string[]>(tags);
 
   const [savedSecretKey, setSavedSecretKey] = useState<string>(password || '');
   const navigate = useNavigate();
   const { patchMutation, isPending } = usePatchRooms();
-  const { title: roomTitleInput, num, secretKey, intro, group } = inputs;
+  const { title, num, secretKey, intro, group } = inputs;
   const isLoading = isPending || isGetDetailLoading;
   const maxCharLimits: { [key: string]: number } = {
     intro: 60,
@@ -104,9 +101,10 @@ const GroupEdit = () => {
 
   const isActive =
     (isPublicGroup || (secretKey.length > 0 && secretKey.length <= 20)) &&
-    roomTitleInput.length > 0 &&
-    roomTitleInput.length <= 20 &&
-    !(Number(num) === 0 || Number(num) > 50) &&
+    title.length > 0 &&
+    title.length <= 20 &&
+    !(num === 0 || num > 50) &&
+    selectedTags !== undefined &&
     selectedTags.length > 0 &&
     intro !== '' &&
     group !== '';
@@ -116,7 +114,7 @@ const GroupEdit = () => {
     if (!isActive) return;
 
     const postData = {
-      title: roomTitleInput,
+      title,
       password: secretKey,
       capacity: num,
       tags: selectedTags,
@@ -146,33 +144,21 @@ const GroupEdit = () => {
   };
 
   useEffect(() => {
-    if (id && !isGetDetailLoading) {
-      const {
-        title: groupTitle,
-        imageSrc,
-        capacity,
-        tags,
-        introduce,
-        information,
-        password,
-      } = data.data;
-
-      const initialData = {
-        title: groupTitle || '',
-        num: capacity ? capacity.toString() : '0',
-        secretKey: password || '',
-        intro: introduce || '',
-        group: information || '',
-        previewImage: imageSrc || null,
-        selectedTags: tags || '',
-      };
-
-      setInputs(initialData);
-      setSelectedTags(initialData.selectedTags);
-      setIsPublicGroup(!password);
-      setPreviewImage(initialData.previewImage);
+    if (!isGetDetailLoading) {
+      setInputs({
+        title: originTitle,
+        num: capacity,
+        secretKey: password,
+        intro: introduce,
+        group: information,
+        previewImage: imageSrc,
+        selectedTags: tags,
+      });
+      /*    setIsPublicGroup(isPublicRoom); */
+      setPreviewImage(imageSrc);
+      setSelectedTags(tags);
     }
-  }, [data]);
+  }, [isGetDetailLoading]);
 
   return (
     <PageLayout category="그룹">
@@ -193,8 +179,8 @@ const GroupEdit = () => {
             handleImageChange={handleImageChange}
           />
           <TitleSection
-            titleValue={roomTitleInput}
-            recruitedValue={inputs.num}
+            titleValue={title}
+            recruitedValue={num.toString()}
             handleMemberCountChange={handleChangeInputs}
           />
           <LanguageSection

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -49,7 +49,9 @@ const GroupEdit = () => {
   const navigate = useNavigate();
   const { patchMutation, isPending } = usePatchRooms();
   const { title, num, secretKey, intro, group } = inputs;
+
   const isLoading = isPending || isGetDetailLoading;
+
   const maxCharLimits: { [key: string]: number } = {
     intro: 60,
     group: 1000,
@@ -169,10 +171,12 @@ const GroupEdit = () => {
             recruitedValue={num.toString()}
             handleMemberCountChange={handleChangeInputs}
           />
-          <LanguageSection
-            selectedTags={selectedTags}
-            setSelectedTags={setSelectedTags}
-          />
+          {selectedTags && (
+            <LanguageSection
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
+            />
+          )}
           <IntroSection
             introValue={intro}
             handleChangeTextarea={handleChangeInputs}

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -11,7 +11,6 @@ import PageLayout from '../components/PageLayout/PageLayout';
 import CommonButton from './../common/CommonButton';
 
 import usePatchRooms from '../libs/hooks/GroupEdit/usePatchRooms';
-import { ALL_TAG, DUMMY } from './../constants/GroupCreate/LanguageConst';
 import useGetDetail from './../libs/hooks/GroupDetail/useGetDetail';
 
 const GroupEdit = () => {
@@ -35,16 +34,17 @@ const GroupEdit = () => {
     intro: introduce || '',
     group: information || '',
     previewImage: imageSrc || null,
+    selectedTags: tags || '',
   };
-  console.log(initialData);
-  const [inputs, setInputs] = useState({ ...initialData });
+
+  const [inputs, setInputs] = useState(initialData);
   const [isPublicGroup, setIsPublicGroup] = useState<boolean>(!password);
   const [previewImage, setPreviewImage] = useState<string | null>(
     initialData.previewImage
   );
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>(
-    tags?.length === DUMMY.length ? [ALL_TAG] : tags || []
+    initialData.selectedTags
   );
 
   const [savedSecretKey, setSavedSecretKey] = useState<string>(password || '');
@@ -163,10 +163,11 @@ const GroupEdit = () => {
         intro: introduce || '',
         group: information || '',
         previewImage: imageSrc || null,
+        selectedTags: tags || '',
       };
 
       setInputs(initialData);
-      setSelectedTags(tags?.length === DUMMY.length ? [ALL_TAG] : tags || []);
+      setSelectedTags(initialData.selectedTags);
       setIsPublicGroup(!password);
       setPreviewImage(initialData.previewImage);
     }

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -101,9 +101,11 @@ const GroupEdit = () => {
   const handleSaveBtnClick = () => {
     if (!isActive) return;
 
+    const trimmedPassword = isPublicGroup ? '' : secretKey.trim();
+
     const postData = {
       title,
-      password: isPublicGroup ? '' : secretKey,
+      password: trimmedPassword,
       capacity: num,
       tags: selectedTags,
       introduce: intro,

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -12,11 +12,12 @@ import CommonButton from './../common/CommonButton';
 
 import usePatchRooms from '../libs/hooks/GroupEdit/usePatchRooms';
 import useGetDetail from './../libs/hooks/GroupDetail/useGetDetail';
+import LoadingPage from './LoadingPage';
 
 const GroupEdit = () => {
   const { id } = useParams();
   if (!id) return;
-  const { data, isLoading } = useGetDetail(parseInt(id));
+  const { data, isLoading: isGetDetailLoading } = useGetDetail(parseInt(id));
 
   const {
     title: groupTitle,
@@ -26,7 +27,7 @@ const GroupEdit = () => {
     introduce,
     information,
     password,
-  } = !isLoading && data?.data;
+  } = !isGetDetailLoading && data?.data;
   const initialData = {
     title: groupTitle || '',
     num: capacity ? capacity.toString() : '0',
@@ -49,9 +50,9 @@ const GroupEdit = () => {
 
   const [savedSecretKey, setSavedSecretKey] = useState<string>(password || '');
   const navigate = useNavigate();
-  const { patchMutation } = usePatchRooms();
+  const { patchMutation, isPending } = usePatchRooms();
   const { title: roomTitleInput, num, secretKey, intro, group } = inputs;
-
+  const isLoading = isPending || isGetDetailLoading;
   const maxCharLimits: { [key: string]: number } = {
     intro: 60,
     group: 1000,
@@ -145,7 +146,7 @@ const GroupEdit = () => {
   };
 
   useEffect(() => {
-    if (id && !isLoading) {
+    if (id && !isGetDetailLoading) {
       const {
         title: groupTitle,
         imageSrc,
@@ -175,47 +176,51 @@ const GroupEdit = () => {
 
   return (
     <PageLayout category="그룹">
-      <Form>
-        <Header>그룹 생성하기</Header>
-        <Borderline />
-        <GroupSetting
-          isPublicGroup={isPublicGroup}
-          handleActiveChange={handleActiveChange}
-          handlePasswordChange={handleChangeInputs}
-          secretKey={inputs.secretKey}
-        />
-        <ImageSection
-          previewImage={previewImage}
-          handleImageChange={handleImageChange}
-        />
-        <TitleSection
-          titleValue={roomTitleInput}
-          recruitedValue={inputs.num}
-          handleMemberCountChange={handleChangeInputs}
-        />
-        <LanguageSection
-          selectedTags={selectedTags}
-          setSelectedTags={setSelectedTags}
-        />
-        <IntroSection
-          introValue={inputs.intro}
-          handleChangeTextarea={handleChangeInputs}
-        />
-        <ProgressSection
-          progressValue={inputs.group}
-          handleChangeTextarea={handleChangeInputs}
-        />
-        <ProfileButton>
-          <CancelButton type="button" onClick={handleCancelBtnClick}>
-            취소하기
-          </CancelButton>
-          <CommonButton
-            isActive={isActive}
-            category="Profile_save"
-            onClick={handleSaveBtnClick}
+      {isLoading ? (
+        <LoadingPage isPageLoading={true} />
+      ) : (
+        <Form>
+          <Header>그룹 생성하기</Header>
+          <Borderline />
+          <GroupSetting
+            isPublicGroup={isPublicGroup}
+            handleActiveChange={handleActiveChange}
+            handlePasswordChange={handleChangeInputs}
+            secretKey={inputs.secretKey}
           />
-        </ProfileButton>
-      </Form>
+          <ImageSection
+            previewImage={previewImage}
+            handleImageChange={handleImageChange}
+          />
+          <TitleSection
+            titleValue={roomTitleInput}
+            recruitedValue={inputs.num}
+            handleMemberCountChange={handleChangeInputs}
+          />
+          <LanguageSection
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
+          />
+          <IntroSection
+            introValue={inputs.intro}
+            handleChangeTextarea={handleChangeInputs}
+          />
+          <ProgressSection
+            progressValue={inputs.group}
+            handleChangeTextarea={handleChangeInputs}
+          />
+          <ProfileButton>
+            <CancelButton type="button" onClick={handleCancelBtnClick}>
+              취소하기
+            </CancelButton>
+            <CommonButton
+              isActive={isActive}
+              category="Profile_save"
+              onClick={handleSaveBtnClick}
+            />
+          </ProfileButton>
+        </Form>
+      )}
     </PageLayout>
   );
 };

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -158,7 +158,7 @@ const GroupEdit = () => {
             isPublicGroup={isPublicGroup}
             handleActiveChange={handleActiveChange}
             handlePasswordChange={handleChangeInputs}
-            secretKey={inputs.secretKey}
+            secretKey={secretKey}
           />
           <ImageSection
             previewImage={previewImage}
@@ -174,11 +174,11 @@ const GroupEdit = () => {
             setSelectedTags={setSelectedTags}
           />
           <IntroSection
-            introValue={inputs.intro}
+            introValue={intro}
             handleChangeTextarea={handleChangeInputs}
           />
           <ProgressSection
-            progressValue={inputs.group}
+            progressValue={group}
             handleChangeTextarea={handleChangeInputs}
           />
           <ProfileButton>

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import GroupSetting from '../components/GroupCreate/GroupSetting';
@@ -36,8 +36,8 @@ const GroupEdit = () => {
     group: information || '',
     previewImage: imageSrc || null,
   };
-
-  const [inputs, setInputs] = useState(initialData);
+  console.log(initialData);
+  const [inputs, setInputs] = useState({ ...initialData });
   const [isPublicGroup, setIsPublicGroup] = useState<boolean>(!password);
   const [previewImage, setPreviewImage] = useState<string | null>(
     initialData.previewImage
@@ -141,8 +141,36 @@ const GroupEdit = () => {
     setSelectedTags(tags || []);
     setIsPublicGroup(!password);
     setSelectedImageFile(null);
-    navigate(`/group/${id}/admin`); // 초기화 후 라우터로 이동
+    navigate(`/group/${id}/admin`);
   };
+
+  useEffect(() => {
+    if (id && !isLoading) {
+      const {
+        title: groupTitle,
+        imageSrc,
+        capacity,
+        tags,
+        introduce,
+        information,
+        password,
+      } = data.data;
+
+      const initialData = {
+        title: groupTitle || '',
+        num: capacity ? capacity.toString() : '0',
+        secretKey: password || '',
+        intro: introduce || '',
+        group: information || '',
+        previewImage: imageSrc || null,
+      };
+
+      setInputs(initialData);
+      setSelectedTags(tags?.length === DUMMY.length ? [ALL_TAG] : tags || []);
+      setIsPublicGroup(!password);
+      setPreviewImage(initialData.previewImage);
+    }
+  }, [data]);
 
   return (
     <PageLayout category="그룹">


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #302 

## ✅ 작업 내용

- [x] 초기값 설정
- [x] 모든 언어가 들어왔을 시 ALL 태그로 대체해야 합니다. -> 수정하지 못함...

## 📸 스크린샷 / GIF / Link
**초기값 설정**

https://github.com/user-attachments/assets/d492b86a-a077-42c5-98a5-9ed8a4f23fb5


## 📌 이슈 사항
## 1️⃣ 초기값 설정
**문제** 
- 새로고침을 하면 useGetDetail이 비동기로 동작하므로, 데이터 로딩 전에는 data가 undefined 상태로 들어왔습니다. 이 시점에서 initialData가 설정되어 빈 값이 들어왔습니다...

**해결**
- GroupEdit에서 데이터 로딩이 완료된 후에 inputs 상태를 설정하도록 수정
- 이를 위해 useEffect를 활용해 초기값을 동적으로 업데이트 했습니다.

**궁금한 점**
- useEffect를 사용해서 해결하는게 맞나요...?
```
useEffect(() => {
    if (id && !isLoading) {
      const {
        title: groupTitle,
        imageSrc,
        capacity,
        tags,
        introduce,
        information,
        password,
      } = data.data;

      const initialData = {
        title: groupTitle || '',
        num: capacity ? capacity.toString() : '0',
        secretKey: password || '',
        intro: introduce || '',
        group: information || '',
        previewImage: imageSrc || null,
        selectedTags: tags || '',
      };

      setInputs(initialData);
      setSelectedTags(initialData.selectedTags);
      setIsPublicGroup(!password);
      setPreviewImage(initialData.previewImage);
    }
  }, [data]);
  ```
--- 
## 2️⃣ ALL태그 
위에 이미지를 보시다시피 서버에서 받아온 언어를 그대로 갖고 오게 구현했습니다. 
```
const [selectedTags, setSelectedTags] = useState<string[]>(
    initialData.selectedTags
  );
  ```
  **문제점**
위에 이미지처럼 갖고 오더라고요... 아래 이미지처럼 갖고 와야 하는데 조건을 따로 줘야 할까요?
이 부분은 전혀 감이 안 와서 구현해두지 못했고 일단 ALL 태그일 때 모든 언어를 받아오게 수정만 한 상태입니다.
![스크린샷 2024-11-17 213015](https://github.com/user-attachments/assets/86ecc2bc-7cc3-4c27-8f7f-6a359c1cf910)
![스크린샷 2024-11-17 213030](https://github.com/user-attachments/assets/90058065-5c9d-4097-a469-a4b9d3632763)

## ✍ 궁금한 것
