### PR TITLE
[ Hotfix ] 연속으로 버튼 클릭 시, 연속으로 등록되지 않도록 수정

### DIFF
--- a/src/common/AlarmModal.tsx
+++ b/src/common/AlarmModal.tsx
@@ -86,7 +86,7 @@ const ModalContainer = styled.ul`
 
   border-radius: 1rem;
   background-color: ${({ theme }) => theme.colors.gray600};
-  overflow-y: scroll;
+  overflow-y: auto;
 
   scrollbar-color: ${({ theme }) => theme.colors.gray500};
 

--- a/src/common/Modal/SaveModalForm.tsx
+++ b/src/common/Modal/SaveModalForm.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { IcCancelSmallWhite, IcSuccess } from '../../assets';
 import usePostTempRecords from '../../libs/hooks/Solve/usePostTempRecords';
 import { ModalProps } from '../../types/Solve/solveTypes';
+import { debounce } from '../../utils/debounce';
 
 const SaveModalForm = ({
   id,
@@ -12,11 +13,18 @@ const SaveModalForm = ({
   codeblocks,
 }: ModalProps) => {
   const { mutation, postTempErr } = usePostTempRecords(onClose);
+  const debouncedMutation = useRef(
+    debounce(
+      () =>
+        questionInfo &&
+        codeblocks &&
+        mutation({ id, questionInfo, codeblocks }),
+      500
+    )
+  );
 
   const handleClickExitBtn = () => {
-    if (questionInfo && codeblocks) {
-      mutation({ id, questionInfo, codeblocks });
-    }
+    debouncedMutation.current();
   };
 
   useEffect(() => {

--- a/src/common/SolutionList/SavedSolution.tsx
+++ b/src/common/SolutionList/SavedSolution.tsx
@@ -54,8 +54,8 @@ const SavedSolutionContainer = styled.article<{
   $removeBorder?: boolean;
   $isModal?: boolean;
 }>`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 81.6rem 10.1rem;
 
   width: 100%;
 
@@ -76,8 +76,8 @@ const SavedSolutionContainer = styled.article<{
 `;
 
 const QuesitonContainer = styled.article`
-  display: flex;
-  gap: 9.7rem;
+  display: grid;
+  grid-template-columns: 16rem 65.6rem;
 `;
 
 const Date = styled.p`

--- a/src/components/Solution/List/TempSave.tsx
+++ b/src/components/Solution/List/TempSave.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { IcArrowRightBig } from '../../../assets';
 import useGetTempRecords from '../../../libs/hooks/Solution/useGetTempRecords';
+import LoadingPage from '../../../page/LoadingPage';
 import Level from '../Level';
 
 const TempSave = () => {
@@ -29,42 +30,46 @@ const TempSave = () => {
 
   return (
     <>
-      {!isLoading && isTempExit && (
-        <TempSaveContainer>
-          <Header>
-            <HeaderTxt>현재 작성하고 있는 문제</HeaderTxt>
-            <SavedSolutionList>
-              {tempArr.map((num) => {
-                return (
-                  <SavedSolutionNum
-                    key={num}
-                    $isActive={clickedPage === num}
-                    $isFirstNum={num === 1}
-                    onClick={() => handleClickSavedSolutionNum(num)}
-                  >
-                    {num}
-                  </SavedSolutionNum>
-                );
-              })}
-            </SavedSolutionList>
-          </Header>
-          <QuestionContainer>
-            <TopInfo>
-              <Title>{title}</Title>
-              <DateContainer>
-                <DateTxt>임시저장</DateTxt>
-                <DateTxt>|</DateTxt>
-                <Date>{createdAt}</Date>
-              </DateContainer>
-            </TopInfo>
+      {isLoading ? (
+        <LoadingPage isPageLoading={true} />
+      ) : (
+        isTempExit && (
+          <TempSaveContainer>
+            <Header>
+              <HeaderTxt>현재 작성하고 있는 문제</HeaderTxt>
+              <SavedSolutionList>
+                {tempArr.map((num) => {
+                  return (
+                    <SavedSolutionNum
+                      key={num}
+                      $isActive={clickedPage === num}
+                      $isFirstNum={num === 1}
+                      onClick={() => handleClickSavedSolutionNum(num)}
+                    >
+                      {num}
+                    </SavedSolutionNum>
+                  );
+                })}
+              </SavedSolutionList>
+            </Header>
+            <QuestionContainer>
+              <TopInfo>
+                <Title>{title}</Title>
+                <DateContainer>
+                  <DateTxt>임시저장</DateTxt>
+                  <DateTxt>|</DateTxt>
+                  <Date>{createdAt}</Date>
+                </DateContainer>
+              </TopInfo>
 
-            <Level level={level} />
-          </QuestionContainer>
-          <WriteBtn type="button" onClick={handleClickWriteBtn}>
-            <BtnTxt>마저 작성하러 가기</BtnTxt>
-            <IcArrowRightBig />
-          </WriteBtn>
-        </TempSaveContainer>
+              <Level level={level} />
+            </QuestionContainer>
+            <WriteBtn type="button" onClick={handleClickWriteBtn}>
+              <BtnTxt>마저 작성하러 가기</BtnTxt>
+              <IcArrowRightBig />
+            </WriteBtn>
+          </TempSaveContainer>
+        )
       )}
     </>
   );

--- a/src/components/Solution/List/TempSave.tsx
+++ b/src/components/Solution/List/TempSave.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import { IcArrowRightBig } from '../../../assets';
+import { IcArrowRightBig, IcInformation } from '../../../assets';
 import useGetTempRecords from '../../../libs/hooks/Solution/useGetTempRecords';
 import LoadingPage from '../../../page/LoadingPage';
 import Level from '../Level';
@@ -36,7 +36,18 @@ const TempSave = () => {
         isTempExit && (
           <TempSaveContainer>
             <Header>
-              <HeaderTxt>현재 작성하고 있는 문제</HeaderTxt>
+              <HeaderTxtContainer>
+                <HeaderTxt>현재 작성하고 있는 문제</HeaderTxt>
+                <InformationContainer>
+                  <Tooltip>
+                    <Notice>문제풀이 임시저장은 총</Notice>
+                    <Point>3개</Point>
+                    <Notice>까지 가능합니다</Notice>
+                  </Tooltip>
+                  <IcInformation />
+                </InformationContainer>
+              </HeaderTxtContainer>
+
               <SavedSolutionList>
                 {tempArr.map((num) => {
                   return (
@@ -98,9 +109,68 @@ const Header = styled.header`
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray600};
 `;
 
+const HeaderTxtContainer = styled.div`
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+`;
+
 const HeaderTxt = styled.span`
   color: ${({ theme }) => theme.colors.gray200};
   ${({ theme }) => theme.fonts.title_bold_16};
+`;
+
+const InformationContainer = styled.div`
+  position: relative;
+
+  &:hover > div {
+    visibility: visible;
+
+    margin: -0.3rem 0 0 -0.2rem;
+    opacity: 1;
+  }
+`;
+
+const Tooltip = styled.div`
+  display: flex;
+  gap: 0.2rem;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 2.9rem;
+  left: -0.6rem;
+  visibility: hidden;
+
+  width: fit-content;
+  padding: 1.2rem 1.1rem;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme }) => theme.colors.gray600};
+
+  white-space: nowrap;
+
+  transition: opacity 0.3s ease-in-out;
+
+  &::after {
+    position: absolute;
+    top: 3.8rem;
+    left: 1.2rem;
+
+    border-color: ${({ theme }) => theme.colors.gray600} transparent transparent;
+    border-width: 5px;
+    border-style: solid;
+    content: '';
+  }
+`;
+
+const Notice = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.body_ligth_12};
+`;
+
+const Point = styled.p`
+  color: ${({ theme }) => theme.colors.codrive_green};
+  ${({ theme }) => theme.fonts.body_ligth_12};
 `;
 
 const SavedSolutionList = styled.div`

--- a/src/components/Solve/Header/HeaderBottom.tsx
+++ b/src/components/Solve/Header/HeaderBottom.tsx
@@ -213,6 +213,19 @@ const OptionContainer = styled.ul<{
 
   text-align: center;
   ${({ theme }) => theme.fonts.body_medium_16};
+
+  scrollbar-color: ${({ theme }) => theme.colors.gray500};
+
+  /* 스크롤바 굵기 설정 */
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+
+  /* 스크롤바 막대 설정 */
+  &::-webkit-scrollbar-thumb {
+    border-radius: 1rem;
+    background-color: ${({ theme }) => theme.colors.gray500};
+  }
 `;
 
 const Option = styled.li<{ $isClickedList: boolean }>`

--- a/src/libs/hooks/GroupCreate/usePostGroup.ts
+++ b/src/libs/hooks/GroupCreate/usePostGroup.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { postGroupInfo } from '../../apis/GroupCreate/postGroupInfo';
+
+const usePostGroup = (previewImage?: string) => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const mutation = useMutation({
+    mutationFn: async (requestBody: FormData) => postGroupInfo(requestBody),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['get-participated-rooms'] });
+      queryClient.invalidateQueries({ queryKey: [['get-recent-rooms']] });
+
+      const { uuid } = res.data;
+      if (uuid) {
+        navigate(`/group-complete/${uuid}`);
+      } else {
+        navigate('/group-complete', {
+          state: {
+            thumbnailUrl: previewImage,
+          },
+        });
+      }
+    },
+  });
+
+  return { mutation: mutation.mutate, isLoading: mutation.isPending };
+};
+
+export default usePostGroup;

--- a/src/libs/hooks/utils/useScrollAnimation.ts
+++ b/src/libs/hooks/utils/useScrollAnimation.ts
@@ -1,0 +1,21 @@
+import { useAnimation, useMotionValueEvent, useScroll } from 'framer-motion';
+
+const useScrollAnimation = () => {
+  const { scrollY } = useScroll();
+  const scrollAnimation = useAnimation();
+
+  useMotionValueEvent(scrollY, 'change', (latest) => {
+    const viewport = window.innerHeight;
+    const scrollValue = window.scrollY;
+
+    if (viewport / latest < viewport) {
+      scrollAnimation.start({ opacity: scrollValue });
+    } else {
+      scrollAnimation.start({ opacity: 0 });
+    }
+  });
+
+  return scrollAnimation;
+};
+
+export default useScrollAnimation;

--- a/src/page/FollowerPage.tsx
+++ b/src/page/FollowerPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowUpBig } from '../assets';
@@ -9,6 +9,8 @@ import ParticipatingGroup from '../components/Follower/Personal/ParticipatingGro
 import Solutions from '../components/Follower/Personal/Solutions';
 import PageLayout from '../components/PageLayout/PageLayout';
 import useGetUserProfile from '../libs/hooks/Follower/useGetUserProfile';
+
+import useScrollAnimation from '../libs/hooks/utils/\buseScrollAnimation';
 import { handleClickGoTopBtn } from '../utils/handleClickGoTopBtn';
 
 const FollowerPage = () => {
@@ -17,16 +19,7 @@ const FollowerPage = () => {
   const userId = parseInt(id);
   const { data, isLoading } = useGetUserProfile(userId) || {};
   const { nickname } = !isLoading && data?.data;
-
-
-  const [opacity, setOpacity] = useState(0);
-
-  useEffect(() => {
-    window.addEventListener('scroll', () => setOpacity(window.scrollY));
-    return () => {
-      window.removeEventListener('scroll', () => setOpacity(window.scrollY));
-    };
-  }, []);
+  const scrollAnimation = useScrollAnimation();
 
   return (
     <PageLayout category="홈">
@@ -42,13 +35,12 @@ const FollowerPage = () => {
           <ParticipatingGroup nickname={nickname} />
 
           <FollowerRecommendCard />
-          <GoTopBtn
-            type="button"
-            onClick={handleClickGoTopBtn}
-            $opacity={opacity}
-          >
-            <IcArrowUpBig />
-          </GoTopBtn>
+
+          <motion.div initial={{ opacity: 0 }} animate={scrollAnimation}>
+            <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
+              <IcArrowUpBig />
+            </GoTopBtn>
+          </motion.div>
         </FollowerPageContainer>
       )}
     </PageLayout>
@@ -76,9 +68,7 @@ const TopContainer = styled.section`
   margin-bottom: 8.8rem;
 `;
 
-const GoTopBtn = styled.button<{ $opacity: number }>`
-  opacity: ${({ $opacity }) => $opacity};
-
+const GoTopBtn = styled.button`
   position: fixed;
   top: calc(100vh - 15rem);
   left: calc(100vw - 22.3rem);

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import CreateButton from '../components/GroupCreate/CreateButton';
 import GroupSetting from '../components/GroupCreate/GroupSetting';
@@ -9,7 +8,8 @@ import LanguageSection from '../components/GroupCreate/LanguageSection';
 import ProgressSection from '../components/GroupCreate/ProgressSection';
 import TitleSection from '../components/GroupCreate/TitleSection';
 import PageLayout from '../components/PageLayout/PageLayout';
-import { postGroupInfo } from '../libs/apis/GroupCreate/postGroupInfo';
+import usePostGroup from '../libs/hooks/GroupCreate/usePostGroup';
+import LoadingPage from './LoadingPage';
 
 const GroupCreate = () => {
   const [inputs, setInputs] = useState({
@@ -24,8 +24,8 @@ const GroupCreate = () => {
   const [previewImage, setPreviewImage] = useState<string | null>('');
   const [selectdImageFile, setSelctedImageFIle] = useState<File | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const navigate = useNavigate();
   const { title, num, secretKey, intro, group } = inputs;
+  const { mutation, isLoading } = usePostGroup();
 
   const maxCharLimits: { [key: string]: number } = {
     intro: 60,
@@ -96,62 +96,51 @@ const GroupCreate = () => {
 
     if (selectdImageFile) {
       requestBody.append('imageFile', selectdImageFile);
-    }
-
-    try {
-      const data = await postGroupInfo(requestBody);
-      const { uuid } = data.data;
-      if (uuid) {
-        navigate(`/group-complete/${uuid}`);
-      } else {
-        navigate('/group-complete', {
-          state: {
-            thumbnailUrl: previewImage,
-          },
-        });
-      }
-    } catch (error) {
-      console.log(error);
+      mutation(requestBody);
     }
   };
 
   return (
     <PageLayout category="그룹">
-      <Form>
-        <Header>그룹 생성하기</Header>
-        <Borderline />
-        <GroupSetting
-          isPublicGroup={isPublicGroup}
-          handleActiveChange={handleActiveChange}
-          handlePasswordChange={handleChangeInputs}
-          secretKey={inputs.secretKey}
-        />
-        <ImageSection
-          previewImage={previewImage}
-          handleImageChange={handleImageChange}
-        />
-        <TitleSection
-          titleValue={inputs.title}
-          recruitedValue={inputs.num}
-          handleMemberCountChange={handleChangeInputs}
-        />
-        <LanguageSection
-          selectedTags={selectedTags}
-          setSelectedTags={setSelectedTags}
-        />
-        <IntroSection
-          introValue={inputs.intro}
-          handleChangeTextarea={handleChangeInputs}
-        />
-        <ProgressSection
-          progressValue={inputs.group}
-          handleChangeTextarea={handleChangeInputs}
-        />
-        <CreateButton
-          isActive={isActive}
-          handleGroupCreate={handleGroupCreate}
-        />
-      </Form>
+      {isLoading ? (
+        <LoadingPage isPageLoading={true} />
+      ) : (
+        <Form>
+          <Header>그룹 생성하기</Header>
+          <Borderline />
+          <GroupSetting
+            isPublicGroup={isPublicGroup}
+            handleActiveChange={handleActiveChange}
+            handlePasswordChange={handleChangeInputs}
+            secretKey={inputs.secretKey}
+          />
+          <ImageSection
+            previewImage={previewImage}
+            handleImageChange={handleImageChange}
+          />
+          <TitleSection
+            titleValue={inputs.title}
+            recruitedValue={inputs.num}
+            handleMemberCountChange={handleChangeInputs}
+          />
+          <LanguageSection
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
+          />
+          <IntroSection
+            introValue={inputs.intro}
+            handleChangeTextarea={handleChangeInputs}
+          />
+          <ProgressSection
+            progressValue={inputs.group}
+            handleChangeTextarea={handleChangeInputs}
+          />
+          <CreateButton
+            isActive={isActive}
+            handleGroupCreate={handleGroupCreate}
+          />
+        </Form>
+      )}
     </PageLayout>
   );
 };

--- a/src/page/SolutionPage.tsx
+++ b/src/page/SolutionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 import { useLocation, useParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { IcArrowUpBig, IcCode } from '../assets';
@@ -8,6 +8,8 @@ import PageLayout from '../components/PageLayout/PageLayout';
 import SolutionHeaderBottom from '../components/Solution/Header/SolutionHeaderBottom';
 import SolutionHeaderTop from '../components/Solution/Header/SolutionHeaderTop';
 import useGetRecords from '../libs/hooks/Solution/useGetRecords';
+
+import useScrollAnimation from '../libs/hooks/utils/\buseScrollAnimation';
 import { handleClickGoTopBtn } from '../utils/handleClickGoTopBtn';
 
 const SolutionPage = () => {
@@ -17,20 +19,16 @@ const SolutionPage = () => {
   const { data, isLoading } = useGetRecords(parseInt(id));
   const { title, level, tags, platform, problemUrl, codeblocks, createdAt } =
     !isLoading && data?.data;
-  const [opacity, setOpacity] = useState(0);
-
-  useEffect(() => {
-    window.addEventListener('scroll', () => setOpacity(window.scrollY));
-    return () => {
-      window.removeEventListener('scroll', () => setOpacity(window.scrollY));
-    };
-  }, []);
+  const scrollAnimation = useScrollAnimation();
 
   return (
     <PageLayout category="문제풀이">
-      <GoTopBtn type="button" onClick={handleClickGoTopBtn} $opacity={opacity}>
-        <IcArrowUpBig />
-      </GoTopBtn>
+      <motion.div style={{ opacity: 0 }} animate={scrollAnimation}>
+        <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
+          <IcArrowUpBig />
+        </GoTopBtn>
+      </motion.div>
+
       {!isLoading && (
         <SolutionPageContainer>
           <SolutionPageHeader>
@@ -138,9 +136,7 @@ const Text = styled.p`
   ${({ theme }) => theme.fonts.body_eng_medium_12};
 `;
 
-const GoTopBtn = styled.button<{ $opacity: number }>`
-  opacity: ${({ $opacity }) => $opacity};
-
+const GoTopBtn = styled.button`
   position: fixed;
   top: calc(100vh - 15rem);
   right: calc(100vw / 8.4211);

--- a/src/page/SolvePage.tsx
+++ b/src/page/SolvePage.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -11,14 +12,16 @@ import {
   CodeProps,
   QuestionInfoProps,
 } from '../types/Solve/solveTypes';
+
+import useScrollAnimation from '../libs/hooks/utils/\buseScrollAnimation';
 import { handleClickGoTopBtn } from '../utils/handleClickGoTopBtn';
 
 const SolvePage = () => {
   const { state } = useLocation();
   const { recordId, isTemp } = state || {};
   const { data, isLoading } = useGetRecords(recordId) || {};
+  const scrollAnimation = useScrollAnimation();
 
-  const [opacity, setOpacity] = useState(0);
   const [isOpenOptions, setIsOpenOptions] = useState(true);
   const [questionInfo, setQuestionInfo] = useState<QuestionInfoProps>({
     title: '',
@@ -121,23 +124,14 @@ const SolvePage = () => {
     }
   }, [data]);
 
-  useEffect(() => {
-    window.addEventListener('scroll', () => setOpacity(window.scrollY));
-    return () => {
-      window.removeEventListener('scroll', () => setOpacity(window.scrollY));
-    };
-  }, []);
-
   return (
     <PageLayout category="문제풀이">
       {ideId > 0 && (
-        <GoTopBtn
-          type="button"
-          onClick={handleClickGoTopBtn}
-          $opacity={opacity}
-        >
-          <IcArrowUpBig />
-        </GoTopBtn>
+        <motion.div style={{ opacity: 0 }} animate={scrollAnimation}>
+          <GoTopBtn type="button" onClick={handleClickGoTopBtn}>
+            <IcArrowUpBig />
+          </GoTopBtn>
+        </motion.div>
       )}
       <SolvePageContainer>
         <PageHeader
@@ -189,9 +183,7 @@ const AddBtnContainer = styled.div`
   margin: 1.8rem 25.7rem 0;
 `;
 
-const GoTopBtn = styled.button<{ $opacity: number }>`
-  opacity: ${({ $opacity }) => $opacity};
-
+const GoTopBtn = styled.button`
   position: fixed;
   top: calc(100vh - 15rem);
   left: calc(100vw - 22.3rem);

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,16 @@
+export const debounce = <F extends (...args: Parameters<F>) => ReturnType<F>>(
+  func: F,
+  timeout = 300
+): ((...args: Parameters<F>) => void) => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  return (...args: Parameters<F>): void => {
+    if (!timer) {
+      func(...args);
+    }
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+    }, timeout);
+  };
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #306 

## ✅ 작업 내용
- [x] 연속으로 임시저장  클릭 시, 연속으로 등록되는 이슈 해결
- [x] 연속으로 그룹 생성 클릭 시, 연속으로 등록되는 이슈 해결
- [x] 임시저장 툴팁 구현
- [x] 문제풀이 등록 플랫폼 선택 부분 스크롤 바 커스텀
- [x] 팔로워 개인 페이지 문제풀이 현황 레이아웃 맞지 않는 부분 수정
- [x] 스크롤을 최상단으로 올리는 버튼이 있는 뷰에서 스크롤 시 화면 깜빡거리는 이슈 해결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/ecaf97cd-005e-4b91-9add-23a9bb395cb5



## 📌 이슈 사항
### 1️⃣ 연속으로 임시저장/ 그룹 생성 클릭 시, 연속으로 등록되는 이슈 해결
1. 그룹 생성
   - 처음에는 디바운스로 해결을 하려고 했는데 로딩처리를 하고나니 연속으로 클릭 자체가 되지 않아서 따로 디바운싱하지는 않았어요!
   - 이 과정에서 안정적이고 간편한 통신을 위해 그룹 생성 api를 커스텀 훅으로 만들고, 리액트 쿼리로 마이그레이션 했어요.

2. 임시 저장
   - 그룹 생성처럼 로딩으로 처리할 수도 있었지만, 현재 임시저장은 모달의 버튼을 클릭했을 때 이뤄지고 있기 때문에 디바운스 처리를 해주었어요.
   - 단순히 디바운스 구현만으로는 연속 처리를 막을 수 없어 찾아보았더니, 디바운스를 정의한 컴포넌트가 렌더링될 때마다 함수가 다시 생성되는 것이 문제였어요.
   - 이를 해결하기 위해 useRef로 디바운스 함수를 감싸주어 값의 변화에도 렌더링이 발생하지 않게 구현했습니다.
   - 참고 자료  🔗: https://velog.io/@seoyaon/Javascript-%EB%94%94%EB%B0%94%EC%9A%B4%EC%8B%B1debouncing%EA%B3%BC-%EC%93%B0%EB%A1%9C%ED%8B%80%EB%A7%81throttling

<br />


### 2️⃣ 스크롤을 최상단으로 올리는 버튼이 있는 뷰에서 스크롤 시 화면 깜빡거리는 이슈 해결
팔로워 개인 뷰에서 스크롤을 할 때마다 화면이 심하게 울렁거리는 현상이 있었어요! 

코드를 살펴보니 스크롤 위치에 따라 버튼의 투명도를 조절하는 함수가 문제였어요. useEffect 내에서 스크롤이 감지될 때마다 투명도를 설정하는 state 값을 변화시키고 있었는데, 이때 state 값이 변화할 때마다 렌더링이 발생하고 있더라구요..!


이와 같은 로직으로 문제를 해결했어요.
1. framer-motion을 활용하여 스크롤 위치에 따라 투명도를 변화시키는 커스텀 훅 구현
2. 버튼에 모션 태그를 씌운 뒤, initial 스타일로 `opacity: 0`을 주고 애니메이션에 미리 구현해둔 투명도 조절 함수 지정