### PR TITLE
[ Hotfix ] 레이아웃 깨지는 부분 수정 및 기능 디벨롭

### DIFF
--- a/src/components/Follower/Personal/ParticipatingGroup.tsx
+++ b/src/components/Follower/Personal/ParticipatingGroup.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { IcSecretBigWhite } from '../../../assets';
 import { ALL_TAG } from '../../../constants/utils/allTag';
 import useGetRooms from '../../../libs/hooks/utils/useGetRooms';
 import {
@@ -74,7 +75,18 @@ const ParticipatingGroup = ({ nickname }: ParticipatingGroupProps) => {
                   })
                 }
               >
-                <Img src={imageSrc} />
+                <CardImgContainer>
+                  {!isPublicRoom && (
+                    <SecretCardBg>
+                      <IcSecretBigWhite />
+                      <SecretCardDesc>
+                        해당 그룹은 비밀그룹 입니다
+                      </SecretCardDesc>
+                    </SecretCardBg>
+                  )}
+                  <Img src={imageSrc} />
+                </CardImgContainer>
+
                 <Contents>
                   <Name>{title}</Name>
                   <TagContainer>
@@ -140,6 +152,32 @@ const CardContainer = styled.div`
 
   width: 100%;
   height: 27.1rem;
+`;
+
+const CardImgContainer = styled.div`
+  position: relative;
+
+  width: 100%;
+  height: 17.8rem;
+`;
+
+const SecretCardBg = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: absolute;
+  inset: 0;
+
+  border-radius: 1.6rem;
+  background-color: ${({ theme }) => theme.colors.gray800};
+  opacity: 0.7;
+`;
+
+const SecretCardDesc = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fonts.body_medium_16};
 `;
 
 const Img = styled.img`

--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -10,6 +10,7 @@ import SearchBar from './groupFilter/SearchBar';
 
 const GroupItem = () => {
   const savedPage = sessionStorage.getItem('savedPage');
+  const savedSorting = sessionStorage.getItem('savedSorting');
 
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [clickedPage, setClickedPage] = useState(
@@ -17,7 +18,7 @@ const GroupItem = () => {
   );
   const [searchResults, setSearchResults] = useState<any[]>([]); // 검색 결과 상태
   const [sliderValues, setSliderValues] = useState({ min: 0, max: 50 });
-  const [sorting, setSorting] = useState('최신순');
+  const [sorting, setSorting] = useState(savedSorting || '최신순');
 
   const ALL_TAG = 'ALL';
   const firstRowTags = ['Python', 'Java', 'JavaScript', 'C++', 'C', 'C#'];
@@ -80,8 +81,9 @@ const GroupItem = () => {
       | React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     const { innerText } = e.currentTarget;
-
     setSorting(innerText);
+
+    sessionStorage.setItem('savedSorting', innerText);
   };
 
   const handleChangeSearchBar = (filteredGroups: any[]) => {

--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -17,11 +17,7 @@ const GroupItem = () => {
   );
   const [searchResults, setSearchResults] = useState<any[]>([]); // 검색 결과 상태
   const [sliderValues, setSliderValues] = useState({ min: 0, max: 50 });
-  const [filter, setFilter] = useState({
-    sorting: '최신순',
-  });
-
-  const { sorting } = filter;
+  const [sorting, setSorting] = useState('최신순');
 
   const ALL_TAG = 'ALL';
   const firstRowTags = ['Python', 'Java', 'JavaScript', 'C++', 'C', 'C#'];
@@ -81,16 +77,11 @@ const GroupItem = () => {
   const handleClickSorting = (
     e:
       | React.MouseEvent<HTMLParagraphElement, MouseEvent>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    isSorting: boolean
+      | React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     const { innerText } = e.currentTarget;
 
-    isSorting;
-    setFilter({
-      ...filter,
-      sorting: innerText,
-    });
+    setSorting(innerText);
   };
 
   const handleChangeSearchBar = (filteredGroups: any[]) => {
@@ -128,7 +119,7 @@ const GroupItem = () => {
         {SORTING.map((standard) => (
           <Sorting
             key={standard}
-            onClick={(e) => standard !== '|' && handleClickSorting(e, true)}
+            onClick={(e) => standard !== '|' && handleClickSorting(e)}
             $isClicked={sorting === standard}
           >
             {standard}

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -5,6 +5,10 @@ import Footer from '../../common/Footer';
 import Header from '../../common/Header';
 import { PageLayoutProps } from '../../types/PageLayout/PageLayoutType';
 import { movePagePosition } from '../../utils/movePagePosition';
+import {
+  removeSavedPage,
+  removeSavedSorting,
+} from '../../utils/removeSavedPage';
 
 const PageLayout = ({
   category,
@@ -38,6 +42,8 @@ const PageLayout = ({
     const { innerHTML } = e.currentTarget;
     setClickedCategory(innerHTML);
     handleEarlyNavigate(innerHTML);
+    removeSavedSorting();
+    removeSavedPage();
   };
 
   useEffect(() => {

--- a/src/page/SolutionPage.tsx
+++ b/src/page/SolutionPage.tsx
@@ -88,7 +88,7 @@ const SolutionPageContainer = styled.section`
   flex-direction: column;
 
   width: 92.6rem;
-  padding: 6.4rem 0 33.2rem;
+  margin: 17.9rem 0 33.2rem;
 `;
 
 const SolutionPageHeader = styled.header`

--- a/src/utils/removeSavedPage.ts
+++ b/src/utils/removeSavedPage.ts
@@ -1,3 +1,7 @@
 export const removeSavedPage = () => {
   sessionStorage.removeItem('savedPage');
 };
+
+export const removeSavedSorting = () => {
+  sessionStorage.removeItem('savedSorting');
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #316 

## ✅ 작업 내용

- [x] 로그인하지 않은 상태로 등록된 문제풀이 다시보기 뷰에 접근한 경우 레이아웃 깨지는 이슈 해결
- [x] 팔로워 개인 뷰 > 참여한 그룹 > 비밀 그룹 표시 (자물쇠)
- [x] 그룹 전체보기 > 그룹 상세 뷰로 넘어갔다 돌아오더라도 선택한 정렬이 유지되도록 수정

## 📸 스크린샷 / GIF / Link

<img width="717" alt="스크린샷 2024-11-24 오후 6 04 43" src="https://github.com/user-attachments/assets/a5ed0138-5b39-442d-9fbe-a40d885c569d">

<img width="717" alt="스크린샷 2024-11-24 오후 6 03 15" src="https://github.com/user-attachments/assets/4d76cadc-bdfb-45f8-afa2-11ac730c9287">

https://github.com/user-attachments/assets/1dd71a04-dfcb-4de4-aa12-43b413c8bdb4


## 📌 이슈 사항
### 1️⃣ 그룹 전체보기 > 그룹 상세 뷰로 넘어갔다 돌아오더라도 선택한 정렬이 유지되도록 수정
기존 코드는 그룹을 정렬하는 부분의 초기값이 항상 '최신순'으로 정의되어 있었기 때문에, 그룹 전체보기 뷰에서 '가나다순'으로 필터링을 걸더라도 그룹 상세 뷰로 접근했다가 뒤로 돌아오면 '최신순'으로 바뀌어 있었어요.
이 부분이 사용자 입장에서 어색하다는 생각이 들어서 그룹 정렬을 선택한 경우, 그룹 상세 뷰로 넘어갔다 오더라도 정렬이 유지되도록 수정했어요.

수정한 로직은 아래와 같아요.
1. 그룹 전체 뷰에서 사용자가 선택한 정렬 값을 세션스토리지에 저장
2. 세션 스토리지에 저장된 값이 있다면 선택한 정렬 값을 저장하는 state의 값을 스토리지 값으로 정의
세션 스토리지에 저장된 값이 없다면 '최신순'으로 초기화