### PR TITLE
[ Hotfix ] p태그로 다시 변경 -> 웹페이지 접근성 측면에서 우위

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -172,7 +172,7 @@ const DateContainer = styled.div`
   position: relative;
 `;
 
-const Year = styled.text`
+const Year = styled.p`
   margin-right: 0.4rem;
   margin-left: 1.4rem;
   cursor: default;
@@ -182,7 +182,7 @@ const Year = styled.text`
   ${({ theme }) => theme.fonts.body_medium_16};
 `;
 
-const Month = styled.text`
+const Month = styled.p`
   margin-right: 0.4rem;
   cursor: default;
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

## ✅ 작업 내용

## 📸 스크린샷 / GIF / Link
<img width="833" alt="image" src="https://github.com/user-attachments/assets/c0d7a832-97ee-4cb8-bbbc-ea36290753f0" />


## 📌 이슈 사항
찾아보니 text 태그는 HTML5 이후부터 사용하지 않는 태그라고 하네요. 
출처 : [MDN](https://developer.mozilla.org/ko/docs/Web/HTML/Element/p)



## ✍ 궁금한 것
