### PR TITLE
[ Hotfix ] 문제풀이 리스트 수가 지정한 것과 다르게 나오는 이슈 해결

### DIFF
--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -126,8 +126,6 @@ const SavedSolutionList = ({
         : handleDisabledMoreBtn(false);
   }, [records]);
 
-  console.log(recordsArr);
-
   return (
     <ListContainer $isSmallList={isSmallList}>
       {!isLoading && (

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -60,7 +60,8 @@ const SavedSolutionList = ({
 
   const { records, totalPage } = !isLoading && data.data;
   const recordsArr =
-    !isLoading && (records.length > 5 ? records.slice(0, 5) : records);
+    !isLoading &&
+    (isSmallList && records.length > 5 ? records.slice(0, 5) : records);
   const pages = Array.from(
     { length: totalPage ? totalPage : 1 },
     (_, idx) => idx + 1
@@ -124,6 +125,8 @@ const SavedSolutionList = ({
         ? handleDisabledMoreBtn(true)
         : handleDisabledMoreBtn(false);
   }, [records]);
+
+  console.log(recordsArr);
 
   return (
     <ListContainer $isSmallList={isSmallList}>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #328 

## ✅ 작업 내용

- [x] 문제풀이 리스트 수가 지정한 것과 다르게 나오는 이슈 해결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/4e06f33d-8ef8-4249-939b-d7659730e7c0


## 📌 이슈 사항
재희가 문제풀이 다시보기 뷰 리스트에서 7개의 문제를 하나의 리스트로 요청하고 있는데, 5개만 나오고 있다고 알려주어서 코드를 확인해보았어요.
문제 리스트가 저장된 배열을 확인해보니, 화면에 렌더링되던 것처럼 5개의 리스트만 보여지고 있더라구요.

문제풀이 리스트를 보여주는 뷰에서 모두 `SavedSolutionList`를 사용하고 있고 `isSmallList`라는 Props를 활용해서 화면에 보여줄 문제풀이 수를 조절해요. 그런데 문제 리스트를 저장하고 있는 배열에서 isSmallList 값과 관계없이, 서버에서 받아온 문제 리스트의 수가 5개를 넘어가면 무조건 5개로 잘라서 보여주고 있었어요.

실제 기획, 디자인과 동일하게 구현하기 위해 문제 리스트를 저장하는 배열을 정의할 때 isSmallList 관련 조건을 추가하여 isSmallList가 true인 경우에만 문제 수를 5개로 제한해서 이슈를 해결했어요.