### PR TITLE
[Refactor] 사파리환경에서 CSS 안보이던 현상 수정

### DIFF
--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -231,7 +231,6 @@ const CardContent = styled.p`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
-  overflow: hidden;
   text-overflow: ellipsis;
 
   height: 5.3rem;

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -231,13 +231,15 @@ const CardContent = styled.p`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
+  overflow: hidden;
+
   text-overflow: ellipsis;
 
-  height: 5.3rem;
+  max-height: 2.8rem;
 
   color: ${({ theme }) => theme.colors.gray300};
+
   ${({ theme }) => theme.fonts.body_ligth_12};
-  flex: 1;
 `;
 
 const CardTags = styled.div`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 내용

사파리환경 CSS 

## 📸 스크린샷 / GIF / Link
### 수정전
![image](https://github.com/user-attachments/assets/4ace3ad0-d52c-4bc4-b708-631b530fee7a)

### 수정후
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/26de5e1f-40fa-4d3b-92f3-9af0b5bd0cb1" />

## 📌 이슈 사항
### 문제코드
```jsx
const CardContent = styled.p`
  display: -webkit-box;
  -webkit-line-clamp: 2;
  -webkit-box-orient: vertical;

  /* overflow: hidden; */
  text-overflow: ellipsis;

  height: 5.3rem;

  color: ${({ theme }) => theme.colors.gray300};
  ${({ theme }) => theme.fonts.body_ligth_12};
  flex: 1;
`;
```
여기서   ```display: -webkit-box : CSS```속성은 블록 컨테이너의 콘텐츠를 지정한 줄 수만큼으로 제한합니다.

`display` 속성을 `-webkit-box` 또는 `-webkit-inline-box`로, 그리고 `-webkit-box-orient` 속성을 `vertical`로 설정한 경우에만 동작한다고 하네요.

여기서 문제되는 점은 overflow : hidden입니다

`-webkit-line-clamp`만 사용하는 경우, 말줄임표는 노출되나 넘친 콘텐츠가 숨겨지지 않으므로 대개 `overflow` 속성 또한 `hidden`으로 설정해야 한다고 합니다.

출처 -> [📎Mdn](https://developer.mozilla.org/ko/docs/Web/CSS/-webkit-line-clamp)
## ✍ 궁금한 것
