### PR TITLE
[ Hofix ] 년도가 바꼈을 때 해당 년도에 저장된 문제풀이 정보가 나오지 않는 이슈 해결

### DIFF
--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -79,6 +79,8 @@ const FilteredContainer = styled.header`
   padding-bottom: 2.2rem;
 
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray600};
+
+  cursor: pointer;
 `;
 
 const DateFilterContainer = styled.div<{ $isCalendarClicked: boolean }>`

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -24,9 +24,10 @@ const SavedSolutionList = ({
 
   const currentYear = new Date().getFullYear();
   const currentMonth = new Date().getMonth() + 1;
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const { unsolvedData, isLoading: isUnsolvedDataLoading } =
     useGetUnsolvedMonths({
-      year: currentYear,
+      year: selectedYear,
       followerId,
     });
   const { months: unsolvedMonths } =
@@ -42,19 +43,17 @@ const SavedSolutionList = ({
 
   const [sorting, setSorting] = useState('최신순');
   const [clickedPage, setClickedPage] = useState(1);
-  const [selectedDate, setSelectedDate] = useState({
-    year: currentYear,
-    month: isRecentSolvedMonthExit ? recentSolvedMonth : currentMonth,
-  });
+  const [selectedMonth, setSelectedMonth] = useState(
+    isRecentSolvedMonthExit ? recentSolvedMonth : currentMonth
+  );
 
-  const { year, month } = selectedDate;
   const { data, isLoading } = isSmallList
     ? useGetRecentFollowerRecords({ userId })
     : useGetMonthlySolution({
         userId: userId,
         sortType: sorting,
-        year: year,
-        month: month,
+        year: selectedYear,
+        month: selectedMonth,
         page: clickedPage - 1,
       });
 
@@ -78,10 +77,7 @@ const SavedSolutionList = ({
     if (isPage) {
       setClickedPage((prev) => prev - 1);
     } else {
-      setSelectedDate({
-        ...selectedDate,
-        year: year - 1,
-      });
+      setSelectedYear((year) => year - 1);
       setClickedPage(1);
     }
 
@@ -94,10 +90,7 @@ const SavedSolutionList = ({
     } else {
       if (e) {
         const clickedMonth = parseInt(e.currentTarget.innerHTML);
-        setSelectedDate({
-          ...selectedDate,
-          month: clickedMonth,
-        });
+        setSelectedMonth(clickedMonth);
         setClickedPage(1);
       }
     }
@@ -109,10 +102,7 @@ const SavedSolutionList = ({
     if (isPage) {
       setClickedPage((prev) => prev + 1);
     } else {
-      setSelectedDate({
-        ...selectedDate,
-        year: year + 1,
-      });
+      setSelectedYear((year) => year + 1);
       setClickedPage(1);
     }
 
@@ -133,8 +123,8 @@ const SavedSolutionList = ({
           {!isSmallList && (
             <ListFilter
               sorting={sorting}
-              year={year}
-              month={month}
+              year={selectedYear}
+              month={selectedMonth}
               unsolvedMonths={unsolvedMonths}
               handleClickSorting={handleClickSorting}
               handleClickPrevBtn={handleClickPrevBtn}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -163,6 +163,8 @@ const NavContainer = styled.div<{ $isClicked: boolean }>`
     css`
       outline: 0.1rem solid ${({ theme }) => theme.colors.gray500};
     `};
+
+  cursor: pointer;
 `;
 
 const DateContainer = styled.div`

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -25,8 +25,7 @@ const CommonCalendar = ({
   const [board, setBoard] = useState<BoardProps[]>([]);
 
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
-  const year = new Date().getFullYear();
-  const { unsolvedData } = useGetUnsolvedMonths({ year });
+  const { unsolvedData } = useGetUnsolvedMonths({ year: clickedYear });
 
   const unsolvedMonths = useRef<Array<number>>([]);
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #335 

## ✅ 작업 내용

- [x] 홈 화면 클릭된 년도 반영
- [x] 저장된 문제풀이 리스트 화면 클릭된 년도 반영

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/ce02a1dd-733d-455b-a95e-b4fb036436e2

https://github.com/user-attachments/assets/8a2f0c54-9a52-4195-b561-a85d3e352675


## 📌 이슈 사항

홈 화면과 저장된 문제풀일 리스트를 보여주는 화면 모두 클릭된 년도가 아닌, `현재 년도`가 unsolvedMonth api의 year로 넘어가고 있어서 클릭된 년도가 바뀌어도 최신 정보가 들어가지 않는 것이 문제였어요.

홈화면에서는 간단히 currentYear를 정의하고 있는 변수를 삭제하고 props로 받아오고 있던 clickedYear를 unsolvedMonth api의 year 정보로 넘겨주는 것으로 문제를 해결했어요.

다만, 저장된 문제풀이 리스트 화면은 코드가 조금 더 복잡했어요. 
클릭된 년도와 월 정보를 하나의 state로 관리하고 있었고, 특히 클릭된 월 정보의 초기값은 unsolvedMonth api에 의존하고 있었기 때문에, 해당 state를 unsolvedMonth api 보다 먼저 정의하여 api의 year에 클릭된 년도를 넘겨주는 방식은 사용할 수 없었어요.

따라서 클릭된 년도와 월 정보를 각각 독립적인 state로 분리했어요. 두 state 모두 기존과 동일하게 값을 초기화하되, 클릭된 년도 state는 unsolvedMonth api를 호출하기 전에 정의하여 해당 api의 year 정보로 넘겨주어 문제를 해결했어요.
클릭된 월 state는 기존과 동일하게 unsolvedMonth api의 하위에 위치시켜 해당 api의 response 값을 사용할 수 있게 구현했어요.
