### PR TITLE
[ Refactor ] 캘린더 Month 클릭 시 캘린더가 다시 닫히게 하도록 수정

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -58,7 +58,6 @@ const CommonCalendar = ({
     const newDate = new Date(clickedYear, month - 1);
     setClickedMonth(month);
     setSelectedDate(newDate);
-    setIsCalendarClicked(false);
   };
 
   const upDatedCalendar = () => {
@@ -71,6 +70,12 @@ const CommonCalendar = ({
   useEffect(() => {
     upDatedCalendar();
   }, [data]);
+
+  useEffect(() => {
+    if (!isCalendarClicked) {
+      setIsCalendarClicked(false);
+    }
+  });
 
   return (
     <CalendarContainer>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 내용

- [ ] 캘린더 Month 클릭 시 캘린더가 다시 닫히게 하도록 수정

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/f63ef3cf-7c09-43cf-8cc1-0fdcf53b11d3


## 📌 이슈 사항

handleClickMonth 함수가 Month를 클릭할 떄 실행되는 함수입니다.

isCalendarClicked가 false 일 떄 캘린더가 닫혀야 해서 false를 넣은것인데, 작동이 되질 않습니다.. 
isCalendarClicked(true) 를 넣어야 캘린더가 닫히더라구요. 하지만 true 일 때 닫히지 말아야 하는게 
```const [isCalendarClicked, setIsCalendarClicked] = useState(false);``` 코드를 보시면 기본값이 false 입니다.
왜 이런 현상이 나타나는지 모르겠습니다..


useEffect를 사용해서 바꾸긴 했는데, 사실 이것도 맞게 한게 아니라고 느껴지는게 
handeClickMonth 함수 안에서 처리를 해야 하는게 맞다고 생각을하고 쓸데없는 useEffect 처리가 늘어났다고 생각하기 떄문입니다.
또한 로직도 정반대로 해야 캘린더가 닫히는 상황이 나오기 때문입니다. 왜그러는걸까요 ? 
```jsx
useEffect(() => {
    if (!isCalendarClicked) {
      setIsCalendarClicked(false);
    }
  });
```


## ✍ 궁금한 것
