### PR TITLE
[ Refactor ] 로그인하지 않은 페이지로 접근 시, 로그인 페이지로 라우팅 (+ 랜딩페이지 주소 변경) 

### DIFF
--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import LandingPage from './page/LandingPage';
+import LoginPage from './page/LoginPage';
+
+const PrivateRoute = ({ exception }: { exception?: boolean }) => {
+  const isLogin = sessionStorage.getItem('token');
+
+  if (!isLogin) {
+    return exception ? <LandingPage /> : <LoginPage />;
+  }
+
+  return <Outlet />;
+};
+export default PrivateRoute;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -21,6 +21,7 @@ import RegisterPage from './page/RegisterPage';
 import SolutionListPage from './page/SolutionListPage';
 import SolutionPage from './page/SolutionPage';
 import SolvePage from './page/SolvePage';
+import PrivateRoute from './PrivateRoute';
 
 const Router = () => {
   return (
@@ -29,31 +30,40 @@ const Router = () => {
         {({ reset }) => (
           <ErrorBoundary onReset={reset}>
             <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/:id" element={<MyProfilePage />} />
-              <Route path="/group" element={<GroupAllPage />} />
-              <Route path="/group/:id" element={<GroupDetail />} />
-              <Route path="/group/:id/admin" element={<AdminPage />} />
-              <Route path="/group/:id/member" element={<GroupMemberPage />} />
-              <Route path="/group-new" element={<GroupCreate />} />
-              <Route path="/my-group" element={<MyGroup />} />
-              <Route path="/group-join" element={<GroupJoin />} />
-              <Route path="/group-complete" element={<GroupComplete />} />
-              <Route path="/group-complete/:id" element={<GroupComplete />} />
-              <Route path="/solve" element={<SolvePage />} />
-              <Route path="/solution" element={<SolutionListPage />} />
+              <Route element={<PrivateRoute exception={true} />}>
+                <Route path="/" element={<Home />} />
+              </Route>
+
+              <Route element={<PrivateRoute />}>
+                <Route path="/:id" element={<MyProfilePage />} />
+                <Route path="/group" element={<GroupAllPage />} />
+                <Route path="/group/:id" element={<GroupDetail />} />
+                <Route path="/group/:id/admin" element={<AdminPage />} />
+                <Route path="/group/:id/member" element={<GroupMemberPage />} />
+                <Route path="/group-new" element={<GroupCreate />} />
+                <Route path="/my-group" element={<MyGroup />} />
+                <Route path="/group-join" element={<GroupJoin />} />
+                <Route path="/group-complete" element={<GroupComplete />} />
+                <Route path="/group-complete/:id" element={<GroupComplete />} />
+                <Route path="/solve" element={<SolvePage />} />
+                <Route path="/solution" element={<SolutionListPage />} />
+                <Route path="/follower" element={<FollowerCurrentPage />} />
+                <Route path="/follower/:id" element={<FollowerPage />} />
+                <Route
+                  path="/follower/:id/total"
+                  element={<TotalSolutions />}
+                />
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  path="/oauth/github/callback"
+                  element={<LoginLoadingPage />}
+                />
+                <Route path="/register" element={<RegisterPage />} />
+                <Route path="/group-all" element={<GroupAllPage />} />
+                <Route path="/group/:id/edit" element={<GroupEdit />} />
+              </Route>
+
               <Route path="/solution/:id" element={<SolutionPage />} />
-              <Route path="/follower" element={<FollowerCurrentPage />} />
-              <Route path="/follower/:id" element={<FollowerPage />} />
-              <Route path="/follower/:id/total" element={<TotalSolutions />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route
-                path="/oauth/github/callback"
-                element={<LoginLoadingPage />}
-              />
-              <Route path="/register" element={<RegisterPage />} />
-              <Route path="/group-all" element={<GroupAllPage />} />
-              <Route path="/group/:id/edit" element={<GroupEdit />} />
             </Routes>
           </ErrorBoundary>
         )}

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -17,9 +17,7 @@ const Home = () => {
 
   useEffect(() => {
     if (!user || isNotRegisted) {
-      !user
-        ? navigate('/login', { state: { isLandingActive: true } })
-        : navigate('/register');
+      navigate('/register');
     }
     return;
   });

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -3,11 +3,10 @@ import styled from 'styled-components';
 import { IcLoginBig } from '../assets';
 import LoginButton from '../components/Login/LoginButton';
 import PageLayout from '../components/PageLayout/PageLayout';
-import LandingPage from './LandingPage';
 
 const LoginPage = () => {
   const { state } = useLocation();
-  const { roomId, isLandingActive } = state || {};
+  const { roomId } = state || {};
 
   const navigate = useNavigate();
   const isAlreadyLogin =
@@ -27,26 +26,20 @@ const LoginPage = () => {
   };
 
   return (
-    <>
-      {isLandingActive ? (
-        <LandingPage />
-      ) : (
-        <PageLayout
-          category={isAlreadyLogin ? '홈' : 'login'}
-          isDisabledFooter={true}
-        >
-          <LoginContainer>
-            <Title>성공적인 코딩테스트를 위한 최적의 경로</Title>
-            <IcLoginBig />
-            {!isAlreadyLogin || isNotResgisted ? (
-              <LoginButton onClick={onClickSocialLogin} />
-            ) : (
-              <HomeBtn onClick={() => navigate('/')}>홈으로</HomeBtn>
-            )}
-          </LoginContainer>
-        </PageLayout>
-      )}
-    </>
+    <PageLayout
+      category={isAlreadyLogin ? '홈' : 'login'}
+      isDisabledFooter={true}
+    >
+      <LoginContainer>
+        <Title>성공적인 코딩테스트를 위한 최적의 경로</Title>
+        <IcLoginBig />
+        {!isAlreadyLogin || isNotResgisted ? (
+          <LoginButton onClick={onClickSocialLogin} />
+        ) : (
+          <HomeBtn onClick={() => navigate('/')}>홈으로</HomeBtn>
+        )}
+      </LoginContainer>
+    </PageLayout>
   );
 };
 

--- a/src/page/SolutionListPage.tsx
+++ b/src/page/SolutionListPage.tsx
@@ -5,8 +5,7 @@ import TempSave from '../components/Solution/List/TempSave';
 
 const SolutionListPage = () => {
   const nickname = sessionStorage.getItem('nickname');
-  const id = sessionStorage.getItem('user');
-  if (!id) return;
+  const id = sessionStorage.getItem('user')!!;
   const userId = parseInt(id);
 
   return (


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #342 

## ✅ 작업 내용

- [x] 로그인하지 않은 페이지로 접근 시, 로그인 페이지로 라우팅
- [x] 랜딩페이지 주소 변경



## 📌 이슈 사항
이전에 로그인 하지 않은 페이지에 대해서 Reactquery의 ErrorBoundary로 로그인 페이지로 라우팅을 시켜주어서 로그인 분기처리를 했었는데요..! 시간이 지날수록 에러 바운더리에서 처리했던건 말 그대로 에러 관련 처리를 했을 뿐, 원래 구현하려 했던 로그인 분기처리가 아닌 것 같다는 생각이 들었어요.

그러던 중 api 통신이 없는 페이지에서는 로그인 없이 접근해도 에러가 발생하지 않기 때문에, 또 다시 이전과 같은 레이아웃 깨짐 현상이 나타난다는 것을 알게 되었어요.
![image](https://github.com/user-attachments/assets/6f35ea25-860a-4bf7-8659-6f6b8bf806c3)

세션 스토리지에서 관리하는 토큰 값과 useNavigate를 활용해서 로그인 분기처리를 해주려고 했으나, App이나 Route 같은 상위 컴포넌트에서는 useNavigate로 라우터를 이동시킬 수 없어 적절한 방법은 아니였어요.
또, 각각의 컴포넌트에서 로그인 여부를 판단하고 그에 따라 분기할 수도 있었지만, 중복코드가 너무 많이 발생하고 있었고 모든 컴포넌트에서 동일한 동작을 매번 수행하는 것이 효율적인 방법은 아니라고 판단했어요.

그래서 전역적인 라우터 관리를 위해 token 값을 활용하여 로그인 여부를 판단하는 PrivateRoute라는 컴포넌트를 하나 만들었어요.
PrivateRoute는 토큰으로 로그인 여부를 판단, 로그인을 하지 않은 상태라면 로그인 페이지를 반환하고 로그인을 한 상태라면 Outlet을 반환해요. 

하지만 예외적으로 홈 컴포넌트에서는 로그인을 하지 않았다면 랜딩페이지를 띄워줘야 했기 때문에, nullable props를 활용하여 해당 값이 true일 때를 예외적인 상황으로 판단해서 랜딩 페이지를 반환해요.
이때 홈 화면에서 로그인이 되지 않은 경우 로그인 페이지로 라우팅 하는 것이 아니라 랜딩 페이지를 띄워주기 때문에, 랜딩 페이지 주소도 홈으로 뜨게 됩니다 !!

로그인 판별이 필요한 모든 컴포넌트를 PrivateRoute로 감싸서 하위 컴포넌트들이 렌더링 되기 전 PrivateRoute를 거치게 하는 방식으로 로그인 분기처리를 구현했어요.



