### PR TITLE
[ Hotfix ] 폰트 정의 방법 수정

### DIFF
--- a/src/common/InformationTooltip.tsx
+++ b/src/common/InformationTooltip.tsx
@@ -72,12 +72,12 @@ const TextContainer = styled.div`
 
 const Nickname = styled.p`
   color: ${({ theme }) => theme.colors.codrive_green};
-  font-size: ${({ theme }) => theme.fonts.detail_regular_12};
+  ${({ theme }) => theme.fonts.detail_regular_12};
 `;
 
 const Text = styled.p`
   color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
+  ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
 `;

--- a/src/components/Admin/GroupStatistics/NumOfMembers.tsx
+++ b/src/components/Admin/GroupStatistics/NumOfMembers.tsx
@@ -81,8 +81,6 @@ const Slash = styled.p`
   margin-left: 0.8rem;
 
   color: ${({ theme }) => theme.colors.gray300};
-  font-weight: 300;
-  font-size: 6.5rem;
 `;
 
 const CapacityContainer = styled.div`

--- a/src/components/GroupAll/GroupRecommend.tsx
+++ b/src/components/GroupAll/GroupRecommend.tsx
@@ -122,7 +122,6 @@ const TooUser = styled.span`
 const Text = styled.p`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.body_ligth_12};
-  line-height: 1.8rem;
 `;
 
 export default GroupRecommend;

--- a/src/components/GroupAll/GroupRecommend.tsx
+++ b/src/components/GroupAll/GroupRecommend.tsx
@@ -91,8 +91,6 @@ const Tooltip = styled.div`
 
   border-radius: 0.8rem;
   background: ${({ theme }) => theme.colors.gray600};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
 

--- a/src/components/GroupCreate/ImageSection.tsx
+++ b/src/components/GroupCreate/ImageSection.tsx
@@ -106,6 +106,7 @@ const EssentialText = styled.p`
 
 const TooltipInfo = styled.div<{ $isVisible: boolean }>`
   display: flex;
+  align-items: center;
   position: relative;
   visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
 
@@ -146,5 +147,4 @@ const TooltipClose = styled.button`
 const LineText = styled.p`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.body_ligth_12};
-  line-height: 1.8rem;
 `;

--- a/src/components/GroupCreate/ImageSection.tsx
+++ b/src/components/GroupCreate/ImageSection.tsx
@@ -115,8 +115,6 @@ const TooltipInfo = styled.div<{ $isVisible: boolean }>`
 
   border-radius: 0.8rem;
   background-color: ${({ theme }) => theme.colors.gray400};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
   transform: translate(8px, -50%);
@@ -147,6 +145,6 @@ const TooltipClose = styled.button`
 
 const LineText = styled.p`
   color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
+  ${({ theme }) => theme.fonts.body_ligth_12};
   line-height: 1.8rem;
 `;

--- a/src/components/Home/TodaySolve.tsx
+++ b/src/components/Home/TodaySolve.tsx
@@ -67,7 +67,9 @@ const TodaySolve = () => {
         <Notic>
           <BtnInformation />
           <Tooltip>
-            목표설정은 우측 상단 닉네임 {'>'} 내 프로필
+            <ToolTipNextLine>
+              목표설정은 우측 상단 닉네임 {'>'} 내 프로필
+            </ToolTipNextLine>
             <ToolTipNextLine>{'>'} 나의 목표에서 설정 가능해요</ToolTipNextLine>
           </Tooltip>
         </Notic>
@@ -166,8 +168,6 @@ const ToolTipNextLine = styled.span`
   display: flex;
   align-items: center;
 
-  margin-top: 0.4rem;
-
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.body_ligth_12};
 `;
@@ -223,7 +223,9 @@ const Notic = styled.div`
 `;
 
 const Tooltip = styled.div`
-  display: block;
+  display: grid;
+  row-gap: 0.4rem;
+
   position: absolute;
   top: 170%;
   visibility: hidden;
@@ -233,8 +235,6 @@ const Tooltip = styled.div`
 
   border-radius: 0.8rem;
   background: ${({ theme }) => theme.colors.gray600};
-  color: ${({ theme }) => theme.colors.white};
-  ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
 

--- a/src/components/Home/WeekRate.tsx
+++ b/src/components/Home/WeekRate.tsx
@@ -186,8 +186,6 @@ const TooltipInfo = styled.div<{ $isVisible: boolean }>`
 
   border-radius: 0.8rem;
   background-color: ${({ theme }) => theme.colors.gray400};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
   transform: translate(8px, -50%);
@@ -266,7 +264,9 @@ const Notic = styled.div`
 `;
 
 const Tooltip = styled.div`
-  display: block;
+  display: grid;
+  row-gap: 0.4rem;
+
   position: absolute;
   top: 2.7rem;
   visibility: hidden;
@@ -277,8 +277,6 @@ const Tooltip = styled.div`
 
   border-radius: 0.8rem;
   background: ${({ theme }) => theme.colors.gray600};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
 
   white-space: nowrap;
 

--- a/src/components/Register/Repositories.tsx
+++ b/src/components/Register/Repositories.tsx
@@ -165,6 +165,6 @@ const TooltipClose = styled.button`
 
 const LineText = styled.p`
   color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fonts.body_ligth_12};
+  ${({ theme }) => theme.fonts.body_ligth_12};
   line-height: 1.8rem;
 `;

--- a/src/components/Register/Repositories.tsx
+++ b/src/components/Register/Repositories.tsx
@@ -166,5 +166,4 @@ const TooltipClose = styled.button`
 const LineText = styled.p`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.body_ligth_12};
-  line-height: 1.8rem;
 `;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #349 

## ✅ 작업 내용

- [x] font-size로 정의 되어있는 것들 `${({ theme }) => theme.fonts.title_bold_24};` 이런 방식으로 다시 정의
- [x] 툴팁 스타일 수정

## 📸 스크린샷 / GIF / Link
![스크린샷 2025-01-13 235349](https://github.com/user-attachments/assets/dd1c5788-e9f7-40d0-972b-af65d994222c)

## 📌 이슈 사항
1. 폰트 사이즈 수정
2. 홈 화면에 오늘 문제풀이 툴팁도 아래 방식으로 수정했습니다. 
```
<Tooltip>
  목표설정은 우측 상단 닉네임 {'>'} 내 프로필
<ToolTipNextLine>{'>'} 나의 목표에서 설정 가능해요</ToolTipNextLine>
 ```
 ```
 <ToolTipNextLine>
    목표설정은 우측 상단 닉네임 {'>'} 내 프로필
</ToolTipNextLine>
<ToolTipNextLine>{'>'} 나의 목표에서 설정 가능해요</ToolTipNextLine>
```
## ✍ 궁금한 것
