### PR TITLE
[ SP2 ] 특정 페이지 선택 -> 상세 뷰로 이동한 후, 뒤로 가기 시 기존 페이지로 복원되는 기능 구현

### DIFF
--- a/src/common/CommonUserList.tsx
+++ b/src/common/CommonUserList.tsx
@@ -21,6 +21,11 @@ import {
   ParticipantType,
   UserType,
 } from '../types/CommonUserList/userListType';
+import {
+  handleClickNextBtn,
+  handleClickPage,
+  handleClickPrevBtn,
+} from '../utils/handleClickPage';
 import ErrorModal from './Modal/ErrorModal/ErrorModal';
 import SaveCheckModal from './Modal/SaveCheckModal/SaveCheckModal';
 import WarningModal from './Modal/WarningModal/WarningModal';
@@ -132,20 +137,6 @@ const CommonUserList = ({
         warningModal: false,
       });
     }
-  };
-
-  const handleClickPrevBtn = () => {
-    const prevPage = (clickedPage - 1).toString();
-    setSearchParams({ page: prevPage });
-  };
-
-  const handleClickPageNumber = (page: number) => {
-    setSearchParams({ page: page.toString() });
-  };
-
-  const handleClickNextBtn = () => {
-    const nextPage = (clickedPage + 1).toString();
-    setSearchParams({ page: nextPage });
   };
 
   useEffect(() => {
@@ -271,7 +262,11 @@ const CommonUserList = ({
 
       <PageNationBar $isEmpty={totalPage === 0}>
         <IcArrowLeftSmallGray
-          onClick={() => clickedPage !== 1 && handleClickPrevBtn()}
+          style={{ cursor: 'pointer' }}
+          onClick={() =>
+            clickedPage !== 1 &&
+            handleClickPrevBtn({ clickedPage, setSearchParams })
+          }
         />
         {pages.map((_, idx) => {
           const page = idx + 1;
@@ -279,14 +274,20 @@ const CommonUserList = ({
             <PageNumber
               key={page}
               $isClicked={totalPage > 0 && clickedPage === page}
-              onClick={() => handleClickPageNumber(page)}
+              onClick={() =>
+                handleClickPage({ clickedPage: page, setSearchParams })
+              }
             >
               {page}
             </PageNumber>
           );
         })}
         <IcArrowRightSmallGray
-          onClick={() => clickedPage !== pages.length && handleClickNextBtn()}
+          style={{ cursor: 'pointer' }}
+          onClick={() =>
+            clickedPage !== pages.length &&
+            handleClickNextBtn({ clickedPage, setSearchParams })
+          }
         />
       </PageNationBar>
 
@@ -497,7 +498,7 @@ const PageNationBar = styled.div<{ $isEmpty: boolean }>`
   margin-top: ${({ $isEmpty }) => ($isEmpty ? `4.8rem` : `8.8rem`)};
 `;
 
-const PageNumber = styled.p<{ $isClicked: boolean }>`
+const PageNumber = styled.button<{ $isClicked: boolean }>`
   padding: 0.4rem 1rem;
 
   border-radius: 0.4rem;

--- a/src/common/CommonUserList.tsx
+++ b/src/common/CommonUserList.tsx
@@ -21,7 +21,6 @@ import {
   ParticipantType,
   UserType,
 } from '../types/CommonUserList/userListType';
-import { removeSavedPage } from '../utils/removeSavedPage';
 import ErrorModal from './Modal/ErrorModal/ErrorModal';
 import SaveCheckModal from './Modal/SaveCheckModal/SaveCheckModal';
 import WarningModal from './Modal/WarningModal/WarningModal';
@@ -35,11 +34,14 @@ const CommonUserList = ({
 }: CommonUserListProps) => {
   const navigate = useNavigate();
 
+  const queryString = location.search;
+  const savedPage = Number(queryString.split('=')[1]);
+
   const [modalOn, setModalOn] = useState({
     warningModal: false,
     saveModal: false,
   });
-  const [clickedPage, setClickedPage] = useState(1);
+  const [clickedPage, setClickedPage] = useState(savedPage || 1);
   const [clickedContents, setClickedContents] = useState({
     clickedId: 0,
     clickedNickname: '',
@@ -136,17 +138,14 @@ const CommonUserList = ({
 
   const handleClickPrevBtn = () => {
     setClickedPage((prev) => prev - 1);
-    removeSavedPage();
   };
 
   const handleClickPageNumber = (page: number) => {
     setClickedPage(page);
-    removeSavedPage();
   };
 
   const handleClickNextBtn = () => {
     setClickedPage((prev) => prev + 1);
-    removeSavedPage();
   };
 
   useEffect(() => {

--- a/src/common/CommonUserList.tsx
+++ b/src/common/CommonUserList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import {
   IcArrowBottomWhite,
@@ -34,14 +34,12 @@ const CommonUserList = ({
 }: CommonUserListProps) => {
   const navigate = useNavigate();
 
-  const queryString = location.search;
-  const savedPage = Number(queryString.split('=')[1]);
-
   const [modalOn, setModalOn] = useState({
     warningModal: false,
     saveModal: false,
   });
-  const [clickedPage, setClickedPage] = useState(savedPage || 1);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const clickedPage = Number(searchParams.get('page'));
   const [clickedContents, setClickedContents] = useState({
     clickedId: 0,
     clickedNickname: '',
@@ -137,15 +135,17 @@ const CommonUserList = ({
   };
 
   const handleClickPrevBtn = () => {
-    setClickedPage((prev) => prev - 1);
+    const prevPage = (clickedPage - 1).toString();
+    setSearchParams({ page: prevPage });
   };
 
   const handleClickPageNumber = (page: number) => {
-    setClickedPage(page);
+    setSearchParams({ page: page.toString() });
   };
 
   const handleClickNextBtn = () => {
-    setClickedPage((prev) => prev + 1);
+    const nextPage = (clickedPage + 1).toString();
+    setSearchParams({ page: nextPage });
   };
 
   useEffect(() => {
@@ -248,10 +248,7 @@ const CommonUserList = ({
                     </Contents>
 
                     {isExitAndClicked && (
-                      <AdditionalProblemsModal
-                        userId={userId}
-                        clickedPage={clickedPage}
-                      />
+                      <AdditionalProblemsModal userId={userId} />
                     )}
                   </ContentsContainer>
 

--- a/src/common/Gnb.tsx
+++ b/src/common/Gnb.tsx
@@ -41,7 +41,7 @@ const Gnb = ({ category, handleOpenGnb }: GnbProps) => {
       case group[1]:
         return navigate('/group-new');
       case group[2]:
-        return navigate('/my-group');
+        return navigate('/my-group?page=1');
       case profile[0]:
         return navigate(`/${username}`);
       case profile[1]:

--- a/src/common/Gnb.tsx
+++ b/src/common/Gnb.tsx
@@ -35,9 +35,9 @@ const Gnb = ({ category, handleOpenGnb }: GnbProps) => {
       case solve[0]:
         return navigate('/solve');
       case solve[1]:
-        return navigate('/solution');
+        return navigate('/solution?page=1');
       case group[0]:
-        return navigate('/group');
+        return navigate('/group?page=1');
       case group[1]:
         return navigate('/group-new');
       case group[2]:

--- a/src/common/Groups.tsx
+++ b/src/common/Groups.tsx
@@ -4,12 +4,9 @@ import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../assets';
 import { PersonalGroupProps } from '../types/MyGroup/myGroupType';
 import RecommendCard from './RecommendCard';
 
-const Groups = ({
-  group,
-  totalPage,
-  clickedPage,
-  handleClickPages,
-}: PersonalGroupProps) => {
+const Groups = ({ group, totalPage, handleClickPages }: PersonalGroupProps) => {
+  const queryString = location.search;
+  const clickedPage = Number(queryString.split('=')[1]);
   const pages = Array.from(
     { length: totalPage > 0 ? totalPage : 1 },
     (_, idx) => idx + 1
@@ -19,11 +16,7 @@ const Groups = ({
 
   return (
     <React.Fragment>
-      <RecommendCard
-        group={group}
-        isLongPage={true}
-        clickedPage={clickedPage}
-      />
+      <RecommendCard group={group} isLongPage={true} />
 
       <PageNationBar>
         <IcArrowLeftSmallGray

--- a/src/common/Groups.tsx
+++ b/src/common/Groups.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../assets';
 import { PersonalGroupProps } from '../types/MyGroup/myGroupType';
+import {
+  handleClickNextBtn,
+  handleClickPage,
+  handleClickPrevBtn,
+} from '../utils/handleClickPage';
 import RecommendCard from './RecommendCard';
 
-const Groups = ({ group, totalPage, handleClickPages }: PersonalGroupProps) => {
-  const queryString = location.search;
-  const clickedPage = Number(queryString.split('=')[1]);
+const Groups = ({ group, totalPage }: PersonalGroupProps) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const clickedPage = Number(searchParams.get('page'));
   const pages = Array.from(
     { length: totalPage > 0 ? totalPage : 1 },
     (_, idx) => idx + 1
   );
-  const { handleClickPrevBtn, handleClickPage, handleClickNextBtn } =
-    handleClickPages;
 
   return (
     <React.Fragment>
@@ -20,21 +24,29 @@ const Groups = ({ group, totalPage, handleClickPages }: PersonalGroupProps) => {
 
       <PageNationBar>
         <IcArrowLeftSmallGray
-          onClick={() => clickedPage > 1 && handleClickPrevBtn()}
+          onClick={() =>
+            clickedPage > 1 &&
+            handleClickPrevBtn({ clickedPage, setSearchParams })
+          }
         />
         {pages.map((page) => {
           return (
             <PageNumber
               key={page}
               $isClicked={totalPage > 0 && clickedPage === page}
-              onClick={() => handleClickPage(page)}
+              onClick={() =>
+                handleClickPage({ clickedPage: page, setSearchParams })
+              }
             >
               {page}
             </PageNumber>
           );
         })}
         <IcArrowRightSmallGray
-          onClick={() => clickedPage !== totalPage && handleClickNextBtn()}
+          onClick={() =>
+            clickedPage !== totalPage &&
+            handleClickNextBtn({ clickedPage, setSearchParams })
+          }
         />
       </PageNationBar>
     </React.Fragment>

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -5,11 +5,7 @@ import { ALL_TAG } from '../constants/utils/allTag';
 import { ClickCardProps } from '../types/Follower/Personal/personalType';
 import { RecommendCardProps } from '../types/GroupAll/RecommendCardType';
 
-const RecommendCard = ({
-  group,
-  isLongPage,
-  clickedPage,
-}: RecommendCardProps) => {
+const RecommendCard = ({ group, isLongPage }: RecommendCardProps) => {
   const navigate = useNavigate();
 
   const handleClickCard = ({
@@ -18,6 +14,8 @@ const RecommendCard = ({
     isMember,
     isPublicRoom,
   }: ClickCardProps) => {
+    const queryStirng = location.search;
+    const clickedPage = Number(queryStirng.split('=')[1]);
     const myId = sessionStorage.getItem('user');
     const isOwner = myId && parseInt(myId) === userId;
     const navigatedPage = isPublicRoom ? `/group/${groupId}` : '/group-join';
@@ -26,14 +24,10 @@ const RecommendCard = ({
       : { roomId: groupId.toString(), notNavigateDetail: true };
 
     if (isOwner) {
-      navigate(
-        `/group/${groupId}/admin${clickedPage && `?page=${clickedPage}`}`
-      );
+      navigate(`/group/${groupId}/admin?page=${clickedPage}`);
     } else {
       isMember
-        ? navigate(
-            `/group/${groupId}/member${clickedPage && `?page=${clickedPage}`}`
-          )
+        ? navigate(`/group/${groupId}/member?page=${clickedPage}`)
         : navigate(navigatedPage, {
             state: navigatedState,
           });

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -26,17 +26,18 @@ const RecommendCard = ({
       : { roomId: groupId.toString(), notNavigateDetail: true };
 
     if (isOwner) {
-      navigate(`/group/${groupId}/admin`);
+      navigate(
+        `/group/${groupId}/admin${clickedPage && `?page=${clickedPage}`}`
+      );
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member`)
+        ? navigate(
+            `/group/${groupId}/member${clickedPage && `?page=${clickedPage}`}`
+          )
         : navigate(navigatedPage, {
             state: navigatedState,
           });
     }
-
-    if (clickedPage)
-      sessionStorage.setItem('savedPage', clickedPage.toString());
   };
 
   return (

--- a/src/common/SolutionList/SavedSolution.tsx
+++ b/src/common/SolutionList/SavedSolution.tsx
@@ -5,7 +5,6 @@ import Level from '../../components/Solution/Level';
 import { SavedSolutionProps } from '../../types/Solution/solutionTypes';
 
 const SavedSolution = ({
-  clickedPage,
   followerId,
   record,
   isModal,
@@ -18,8 +17,6 @@ const SavedSolution = ({
 
   const handleClickArrow = () => {
     navigate(`/solution/${recordId}`, { state: followerId });
-    if (clickedPage)
-      sessionStorage.setItem('savedPage', clickedPage.toString());
   };
 
   return (

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
 import useGetRecentFollowerRecords from '../../libs/hooks/Follower/useGetRecentFollowerRecords';
@@ -9,7 +10,6 @@ import {
   recordType,
   SavedSolutionListProps,
 } from '../../types/Solution/solutionTypes';
-import { removeSavedPage } from '../../utils/removeSavedPage';
 import ListFilter from './ListFilter';
 import SavedSolution from './SavedSolution';
 
@@ -41,8 +41,10 @@ const SavedSolutionList = ({
     !isUnsolvedDataLoading && solvedMonths && Math.max(...solvedMonths);
   const isRecentSolvedMonthExit = recentSolvedMonth && recentSolvedMonth > 0;
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const [sorting, setSorting] = useState('최신순');
-  const [clickedPage, setClickedPage] = useState(1);
+  const [clickedPage, setClickedPage] = useState(Number(searchParams) || 1);
   const [selectedMonth, setSelectedMonth] = useState(
     isRecentSolvedMonthExit ? recentSolvedMonth : currentMonth
   );
@@ -75,38 +77,46 @@ const SavedSolutionList = ({
 
   const handleClickPrevBtn = (isPage: boolean) => {
     if (isPage) {
-      setClickedPage((prev) => prev - 1);
+      setClickedPage((prev) => {
+        const prevPage = prev - 1;
+        setSearchParams({ page: prevPage.toString() });
+        return prevPage;
+      });
     } else {
       setSelectedYear((year) => year - 1);
       setClickedPage(1);
+      setSearchParams({ page: '1' });
     }
 
-    removeSavedPage();
+    setSearchParams({ page: clickedPage.toString() });
   };
 
   const handleClickValue = ({ e, value }: ClickedValueProps) => {
     if (value) {
       setClickedPage(value);
+      setSearchParams({ page: value.toString() });
     } else {
       if (e) {
         const clickedMonth = parseInt(e.currentTarget.innerHTML);
         setSelectedMonth(clickedMonth);
         setClickedPage(1);
+        setSearchParams({ page: '1' });
       }
     }
-
-    removeSavedPage();
   };
 
   const handleClickNextBtn = (isPage: boolean) => {
     if (isPage) {
-      setClickedPage((prev) => prev + 1);
+      setClickedPage((prev) => {
+        const nextPage = prev + 1;
+        setSearchParams({ page: nextPage.toString() });
+        return nextPage;
+      });
     } else {
       setSelectedYear((year) => year + 1);
       setClickedPage(1);
+      setSearchParams({ page: '1' });
     }
-
-    removeSavedPage();
   };
 
   useEffect(() => {

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -42,9 +42,9 @@ const SavedSolutionList = ({
   const isRecentSolvedMonthExit = recentSolvedMonth && recentSolvedMonth > 0;
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const clickedPage = Number(searchParams.get('page'));
 
   const [sorting, setSorting] = useState('최신순');
-  const [clickedPage, setClickedPage] = useState(Number(searchParams) || 1);
   const [selectedMonth, setSelectedMonth] = useState(
     isRecentSolvedMonthExit ? recentSolvedMonth : currentMonth
   );
@@ -77,14 +77,10 @@ const SavedSolutionList = ({
 
   const handleClickPrevBtn = (isPage: boolean) => {
     if (isPage) {
-      setClickedPage((prev) => {
-        const prevPage = prev - 1;
-        setSearchParams({ page: prevPage.toString() });
-        return prevPage;
-      });
+      const prevPage = (clickedPage - 1).toString();
+      setSearchParams({ page: prevPage });
     } else {
       setSelectedYear((year) => year - 1);
-      setClickedPage(1);
       setSearchParams({ page: '1' });
     }
 
@@ -93,13 +89,11 @@ const SavedSolutionList = ({
 
   const handleClickValue = ({ e, value }: ClickedValueProps) => {
     if (value) {
-      setClickedPage(value);
       setSearchParams({ page: value.toString() });
     } else {
       if (e) {
         const clickedMonth = parseInt(e.currentTarget.innerHTML);
         setSelectedMonth(clickedMonth);
-        setClickedPage(1);
         setSearchParams({ page: '1' });
       }
     }
@@ -107,14 +101,10 @@ const SavedSolutionList = ({
 
   const handleClickNextBtn = (isPage: boolean) => {
     if (isPage) {
-      setClickedPage((prev) => {
-        const nextPage = prev + 1;
-        setSearchParams({ page: nextPage.toString() });
-        return nextPage;
-      });
+      const nextPage = (clickedPage + 1).toString();
+      setSearchParams({ page: nextPage });
     } else {
       setSelectedYear((year) => year + 1);
-      setClickedPage(1);
       setSearchParams({ page: '1' });
     }
   };
@@ -149,7 +139,6 @@ const SavedSolutionList = ({
                 key={record.recordId}
                 followerId={followerId}
                 record={record}
-                clickedPage={clickedPage}
               />
             );
           })}

--- a/src/components/Follower/Current/AdditionalProblemsModal.tsx
+++ b/src/components/Follower/Current/AdditionalProblemsModal.tsx
@@ -6,10 +6,7 @@ import {
   FollowerRecordsType,
 } from '../../../types/Follower/Current/currentType';
 
-const AdditionalProblemsModal = ({
-  userId,
-  clickedPage,
-}: AdditionalProblemsModalProps) => {
+const AdditionalProblemsModal = ({ userId }: AdditionalProblemsModalProps) => {
   const { data, isLoading } = useGetRecentFollowerRecords({ userId });
   const { records } = !isLoading && data.data;
 
@@ -26,7 +23,6 @@ const AdditionalProblemsModal = ({
                   record={record}
                   isModal={true}
                   removeBorder={idx === records.length - 1}
-                  clickedPage={clickedPage}
                 />
               );
             })}

--- a/src/components/Follower/Personal/ParticipatingGroup.tsx
+++ b/src/components/Follower/Personal/ParticipatingGroup.tsx
@@ -30,10 +30,10 @@ const ParticipatingGroup = ({ nickname }: ParticipatingGroupProps) => {
   }: ClickCardProps) => {
     const myId = sessionStorage.getItem('user');
     if (myId && parseInt(myId) === userId) {
-      navigate(`/group/${groupId}/admin`);
+      navigate(`/group/${groupId}/admin?page=1`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member`)
+        ? navigate(`/group/${groupId}/member?page=1`)
         : navigate(`/group/${groupId}`, {
             state: { isPublicRoom: isPublicRoom },
           });

--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -90,20 +90,6 @@ const GroupItem = () => {
     setSearchResults(filteredGroups);
   };
 
-  const handleClickPrevBtn = () => {
-    const prevPage = (clickedPage - 1).toString();
-    setSearchParams({ page: prevPage });
-  };
-
-  const handleClickPage = (page: number) => {
-    setSearchParams({ page: page.toString() });
-  };
-
-  const handleClickNextBtn = () => {
-    const nextPage = (clickedPage + 1).toString();
-    setSearchParams({ page: nextPage });
-  };
-
   return (
     <GroupContainer>
       <GroupTitle>그룹 전체 보기</GroupTitle>
@@ -128,15 +114,7 @@ const GroupItem = () => {
         ))}
       </SortContainer>
       <GroupsItemContainer>
-        <Groups
-          group={searchResults}
-          totalPage={totalPageRef.current}
-          handleClickPages={{
-            handleClickPrevBtn: handleClickPrevBtn,
-            handleClickPage: handleClickPage,
-            handleClickNextBtn: handleClickNextBtn,
-          }}
-        />
+        <Groups group={searchResults} totalPage={totalPageRef.current} />
       </GroupsItemContainer>
     </GroupContainer>
   );

--- a/src/components/GroupAll/GroupItem.tsx
+++ b/src/components/GroupAll/GroupItem.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Groups from '../../common/Groups';
 import { SORTING } from '../../constants/Follower/currentConst';
 import useGetRoomsSort from '../../libs/hooks/GroupAll/useGetRoomSort';
 import { GroupsItemProps } from '../../types/GroupItem/groupItemType';
-import { removeSavedPage } from '../../utils/removeSavedPage';
 import {
   ALL_TAG,
   FIRST_TAGS,
@@ -14,13 +14,11 @@ import LanguageSelectBox from './groupFilter/LanguageSelectBox';
 import SearchBar from './groupFilter/SearchBar';
 
 const GroupItem = () => {
-  const savedPage = sessionStorage.getItem('savedPage');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const clickedPage = Number(searchParams.get('page'));
   const savedSorting = sessionStorage.getItem('savedSorting');
 
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [clickedPage, setClickedPage] = useState(
-    savedPage ? parseInt(savedPage) : 1
-  );
   const [searchResults, setSearchResults] = useState<any[]>([]); // 검색 결과 상태
   const [sliderValues, setSliderValues] = useState({ min: 0, max: 50 });
   const [sorting, setSorting] = useState(savedSorting || '최신순');
@@ -69,10 +67,11 @@ const GroupItem = () => {
   useEffect(() => {
     if (rooms) {
       const filteredGroups = filterGroups(rooms);
+      const page = Math.min(clickedPage, totalPageRef.current).toString();
       setSearchResults(filteredGroups);
 
       totalPageRef.current = totalPage || 1;
-      setClickedPage((prevPage) => Math.min(prevPage, totalPageRef.current));
+      setSearchParams({ page: page });
     }
   }, [rooms, sorting, clickedPage, selectedTags, sliderValues]);
 
@@ -92,18 +91,17 @@ const GroupItem = () => {
   };
 
   const handleClickPrevBtn = () => {
-    setClickedPage((prev) => prev - 1);
-    removeSavedPage();
+    const prevPage = (clickedPage - 1).toString();
+    setSearchParams({ page: prevPage });
   };
 
   const handleClickPage = (page: number) => {
-    setClickedPage(page);
-    removeSavedPage();
+    setSearchParams({ page: page.toString() });
   };
 
   const handleClickNextBtn = () => {
-    setClickedPage((prev) => prev + 1);
-    removeSavedPage();
+    const nextPage = (clickedPage + 1).toString();
+    setSearchParams({ page: nextPage });
   };
 
   return (
@@ -133,7 +131,6 @@ const GroupItem = () => {
         <Groups
           group={searchResults}
           totalPage={totalPageRef.current}
-          clickedPage={clickedPage}
           handleClickPages={{
             handleClickPrevBtn: handleClickPrevBtn,
             handleClickPage: handleClickPage,

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -16,7 +16,7 @@ const WeeklyFollower = () => {
   const hasFollowers = !isLoading && followings.length > 0;
 
   const handleClickAllButton = () => {
-    navigate('/follower');
+    navigate('/follower?page=1');
   };
 
   while (!isLoading && followings.length < 3) {

--- a/src/components/MyGroup/ActiveGroups.tsx
+++ b/src/components/MyGroup/ActiveGroups.tsx
@@ -42,10 +42,10 @@ const ActiveGroups = ({ totalActiveGroups }: ActiveGroupProps) => {
   }: ClickCardProps) => {
     const myId = sessionStorage.getItem('user');
     if (myId && parseInt(myId) === userId) {
-      navigate(`/group/${groupId}/admin`);
+      navigate(`/group/${groupId}/admin?page=1`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member`)
+        ? navigate(`/group/${groupId}/member?page=1`)
         : navigate(`/group/${groupId}`, {
             state: { isPublicRoom: isPublicRoom },
           });

--- a/src/components/MyGroup/PersonalGroup.tsx
+++ b/src/components/MyGroup/PersonalGroup.tsx
@@ -77,19 +77,6 @@ const PersonalGroup = () => {
     setSearchParams({ page: '1' });
   };
 
-  const handleClickPrevBtn = () => {
-    const prevPage = (clickedPage - 1).toString();
-    setSearchParams({ page: prevPage });
-  };
-
-  const handleClickPage = (page: number) => {
-    setSearchParams({ page: page.toString() });
-  };
-
-  const handleClickNextBtn = () => {
-    const nextPage = (clickedPage + 1).toString();
-    setSearchParams({ page: nextPage });
-  };
   return (
     <PersonalGroupContainer>
       <Header>
@@ -140,17 +127,7 @@ const PersonalGroup = () => {
           })}
         </SortContainer>
       </TopContainer>
-      {!isLoading && (
-        <Groups
-          group={group}
-          totalPage={totalPage}
-          handleClickPages={{
-            handleClickPrevBtn: handleClickPrevBtn,
-            handleClickPage: handleClickPage,
-            handleClickNextBtn: handleClickNextBtn,
-          }}
-        />
-      )}
+      {!isLoading && <Groups group={group} totalPage={totalPage} />}
     </PersonalGroupContainer>
   );
 };

--- a/src/components/MyGroup/PersonalGroup.tsx
+++ b/src/components/MyGroup/PersonalGroup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import {
   IcStatusBlack,
@@ -9,16 +10,14 @@ import {
 import Groups from '../../common/Groups';
 import { SORTING, STATUS } from '../../constants/Follower/currentConst';
 import useGetRooms from '../../libs/hooks/utils/useGetRooms';
-import { removeSavedPage } from '../../utils/removeSavedPage';
 
 const PersonalGroup = () => {
   const GROUP_CATEGORY = ['내가 참여한 그룹', '내가 생성한 그룹'];
-  const savedPage = sessionStorage.getItem('savedPage');
   const savedCategory = sessionStorage.getItem('savedCategory');
 
-  const [clickedPage, setClickedPage] = useState(
-    savedPage ? parseInt(savedPage) : 1
-  );
+  const [searchParams, setSearchParams] = useSearchParams();
+  const clickedPage = Number(searchParams.get('page'));
+
   const [clickedCategry, setClickedCategory] = useState(
     savedCategory ? savedCategory : GROUP_CATEGORY[0]
   );
@@ -75,24 +74,22 @@ const PersonalGroup = () => {
     setClickedCategory(innerHTML);
     sessionStorage.setItem('savedCategory', innerHTML);
 
-    setClickedPage(1);
+    setSearchParams({ page: '1' });
   };
 
   const handleClickPrevBtn = () => {
-    setClickedPage((prev) => prev - 1);
-    removeSavedPage();
+    const prevPage = (clickedPage - 1).toString();
+    setSearchParams({ page: prevPage });
   };
 
   const handleClickPage = (page: number) => {
-    setClickedPage(page);
-    removeSavedPage();
+    setSearchParams({ page: page.toString() });
   };
 
   const handleClickNextBtn = () => {
-    setClickedPage((prev) => prev + 1);
-    removeSavedPage();
+    const nextPage = (clickedPage + 1).toString();
+    setSearchParams({ page: nextPage });
   };
-
   return (
     <PersonalGroupContainer>
       <Header>
@@ -147,7 +144,6 @@ const PersonalGroup = () => {
         <Groups
           group={group}
           totalPage={totalPage}
-          clickedPage={clickedPage}
           handleClickPages={{
             handleClickPrevBtn: handleClickPrevBtn,
             handleClickPage: handleClickPage,

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -5,10 +5,6 @@ import Footer from '../../common/Footer';
 import Header from '../../common/Header';
 import { PageLayoutProps } from '../../types/PageLayout/PageLayoutType';
 import { movePagePosition } from '../../utils/movePagePosition';
-import {
-  removeSavedPage,
-  removeSavedSorting,
-} from '../../utils/removeSavedPage';
 
 const PageLayout = ({
   category,
@@ -42,8 +38,6 @@ const PageLayout = ({
     const { innerHTML } = e.currentTarget;
     setClickedCategory(innerHTML);
     handleEarlyNavigate(innerHTML);
-    removeSavedSorting();
-    removeSavedPage();
   };
 
   useEffect(() => {

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -26,7 +26,7 @@ const PageLayout = ({
       case '문제풀이':
         return navigate('/solve');
       case '그룹':
-        return navigate('/group');
+        return navigate('/group?page=1');
       default:
         return navigate('/login');
     }

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -26,10 +26,10 @@ const usePostAlarmRead = () => {
           navigate(`/follower/${dataId}`);
           break;
         case 'CREATED_PUBLIC_ROOM_REQUEST':
-          navigate(`/group/${dataId}/admin`);
+          navigate(`/group/${dataId}/admin?page=1`);
           break;
         case 'CREATED_PRIVATE_ROOM_JOIN':
-          navigate(`/group/${dataId}/admin`);
+          navigate(`/group/${dataId}/admin?page=1`);
           break;
         case 'PUBLIC_ROOM_REQUEST':
           navigate(`/group/${dataId}`, {
@@ -37,10 +37,10 @@ const usePostAlarmRead = () => {
           }); // state 를 true로 변경하여 신청하기 버튼 없애기
           break;
         case 'PUBLIC_ROOM_APPROVE':
-          navigate(`/group/${dataId}/member`);
+          navigate(`/group/${dataId}/member?page=1`);
           break;
         case 'ROOM_STATUS_INACTIVE':
-          navigate('/my-group');
+          navigate('/my-group?page=1');
           break;
       }
       queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });

--- a/src/libs/hooks/GroupEdit/usePatchRooms.ts
+++ b/src/libs/hooks/GroupEdit/usePatchRooms.ts
@@ -21,7 +21,7 @@ const usePatchRooms = () => {
       // roomId를 queryKey와 navigate에 사용
       queryClient.invalidateQueries({ queryKey: ['get-detail', roomId] });
       queryClient.invalidateQueries({ queryKey: ['get-rooms-id'] });
-      navigate(`/group/${roomId}/admin`);
+      navigate(`/group/${roomId}/admin?page=1`);
     },
     onError: (err: any) => {
       const message = err?.response?.data?.message || 'Something went wrong';

--- a/src/libs/hooks/GroupJoin/usePostAnswer.ts
+++ b/src/libs/hooks/GroupJoin/usePostAnswer.ts
@@ -9,7 +9,7 @@ const usePostAnswer = (roomId: number) => {
     mutationFn: async ({ roomId, password }: PostAnswerProps) =>
       await postAnswer({ roomId, password }),
     onSuccess: () => {
-      navigate(`/group/${roomId}/member`);
+      navigate(`/group/${roomId}/member?page=1`);
     },
     onError: (err: { response: { data: { message: string } } }) => {
       const { message } = err.response.data;

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -51,7 +51,7 @@ const GroupComplete = () => {
   const handleGroupPageRedirect = async () => {
     if (token && nickname) {
       const data = await getGroupInfo(uuid!);
-      navigate(`/group/${data.roomId}/admin`);
+      navigate(`/group/${data.roomId}/admin?page=1`);
     }
   };
 

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -130,7 +130,7 @@ const GroupEdit = () => {
     setSelectedTags(tags || []);
     setIsPublicGroup(!password);
     setSelectedImageFile(null);
-    navigate(`/group/${id}/admin`);
+    navigate(`/group/${id}/admin?page=1`);
   };
 
   useEffect(() => {

--- a/src/types/Follower/Current/currentType.ts
+++ b/src/types/Follower/Current/currentType.ts
@@ -55,7 +55,6 @@ export interface FollowerFilterProps {
 
 export interface AdditionalProblemsModalProps {
   userId: number;
-  clickedPage?: number;
 }
 
 export interface FollowerRecordsType {

--- a/src/types/GroupAll/RecommendCardType.ts
+++ b/src/types/GroupAll/RecommendCardType.ts
@@ -16,5 +16,4 @@ export interface RecommendCardProps {
     isPublicRoom: boolean;
   }>;
   isLongPage: boolean;
-  clickedPage?: number;
 }

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -30,11 +30,6 @@ export interface GroupType {
 export interface PersonalGroupProps {
   totalPage: number;
   group: Array<GroupType>;
-  handleClickPages: {
-    handleClickPrevBtn: () => void;
-    handleClickPage: (page: number) => void;
-    handleClickNextBtn: () => void;
-  };
 }
 
 export interface GetRoomsProps {

--- a/src/types/MyGroup/myGroupType.ts
+++ b/src/types/MyGroup/myGroupType.ts
@@ -30,7 +30,6 @@ export interface GroupType {
 export interface PersonalGroupProps {
   totalPage: number;
   group: Array<GroupType>;
-  clickedPage: number;
   handleClickPages: {
     handleClickPrevBtn: () => void;
     handleClickPage: (page: number) => void;

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -38,7 +38,6 @@ export interface recordType {
 export interface SavedSolutionProps {
   record: recordType;
   followerId?: number;
-  clickedPage?: number;
   isModal?: boolean;
   removeBorder?: boolean;
 }

--- a/src/utils/handleClickPage.ts
+++ b/src/utils/handleClickPage.ts
@@ -1,0 +1,29 @@
+import { SetURLSearchParams } from 'react-router-dom';
+
+type clickedPageType = {
+  clickedPage: number;
+  setSearchParams: SetURLSearchParams;
+};
+
+export const handleClickPrevBtn = ({
+  clickedPage,
+  setSearchParams,
+}: clickedPageType) => {
+  const prevPage = (clickedPage - 1).toString();
+  setSearchParams({ page: prevPage });
+};
+
+export const handleClickPage = ({
+  clickedPage,
+  setSearchParams,
+}: clickedPageType) => {
+  setSearchParams({ page: clickedPage.toString() });
+};
+
+export const handleClickNextBtn = ({
+  clickedPage,
+  setSearchParams,
+}: clickedPageType) => {
+  const nextPage = (clickedPage + 1).toString();
+  setSearchParams({ page: nextPage });
+};

--- a/src/utils/removeSavedPage.ts
+++ b/src/utils/removeSavedPage.ts
@@ -1,7 +1,0 @@
-export const removeSavedPage = () => {
-  sessionStorage.removeItem('savedPage');
-};
-
-export const removeSavedSorting = () => {
-  sessionStorage.removeItem('savedSorting');
-};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #362 

## ✅ 작업 내용

- [x] 특정 페이지 선택 -> 상세 뷰로 이동한 후, 뒤로 가기 시 기존 페이지로 복원되는 기능 구현

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/80b47649-4b41-47be-9af4-45206500dd0c


<br />

## 📌 이슈 사항
예전에 기능 개발할 때 선택한 페이지가 뒤로 가기를 했을 때도 유지되게 하기 위해서 session storage를 사용했었어요. 추가 개발을 진행하며 관련 로직이 꼬여있는 것을 확인해서 session storage로 관리하던 페이지 정보를 모두 제거했어요.
(ex. a 페이지에서 2페이지 선택 후 b 페이지로 이동 -> b 페이지에 처음 접근했음에도 페이지 선택이 2페이지로 되어 있는 것을 확인)

선택한 페이지를 관리하는 기능이 없다보니, 페이지를 선택하고 상세뷰로 접근했다가 뒤로 가기 버튼을 클릭했을 때 이전에 접근한 페이지가 아닌 첫번째 페이지로 초기화되어 사용자 입장에서 매우매우 불편하고 불친절하게 느껴졌어요. 여러 사이트를 경험하다 보니 보통은 선택한 페이지나 년도, 레벨 등 보안이 중요하지 않은 정보는 query string으로 처리하는 것을 알 수 있었어요. 
기존에 구현해둔 라우터를 수정하지 않아도 되고, 각 페이지마다 정보를 따로 관리하니 이전처럼 로직이 꼬이지 않는다는 장점이 있어 해당 방법을 선택했어요. 이렇게 구현하니 불필요한 props나 state 정의 부분이 발생해서 해당 부분은 모두 제거해주었어요.  
또한, 화살표 버튼이나 숫자 클릭으로 페이지를 이동하는 함수 로직이 중복되는 경우가 많아서 해당 부분은 유틸로 분리해주었어요!

추후 사용자가 선택한 년도와 정렬(최신순, 오래된순, 가나다순 등) 부분도 query string을 활용한 방식으로 수정할 예정이예요.

<br />

## ✍ 궁금한 것
`GroupAll > GroupItem.tsx` 컴포넌트의 useEffect 부분을 보면 아래와 같이 정의되어 있어요.
```typescript
  useEffect(() => {
    if (rooms) {
      const filteredGroups = filterGroups(rooms);
      setSearchResults(filteredGroups);

      totalPageRef.current = totalPage || 1;
      setClickedPage((prevPage) => Math.min(prevPage, totalPageRef.current));
    }
  }, [rooms, sorting, clickedPage, selectedTags, sliderValues]);
```

여기서 setClickedPage 부분을 보면 clickedPage와 전체 페이지 정보를 비교해서 `더 작은 수`를 clickedPage에 할당하고 있더라구요. 
사실 clickedPage에는 사용자가 클릭한 페이지 정보 자체가 바로 들어가는게 맞는 로직이라고 생각하는데, 아래와 같이 클릭된 페이지와 전체 페이지 값 중 최솟값을 clickedPage로 정의하는 이유가 궁금해요 !!
```typescript
setClickedPage((prevPage) => Math.min(prevPage, totalPageRef.current));
```