### PR TITLE
[ SP2 ] 선택된 정렬(최신순 / 가나다순 / 오래된 순)이 뒤로 가기로 돌아왔을 때에도 유지되도록 구현

### DIFF
--- a/src/common/CommonUserList.tsx
+++ b/src/common/CommonUserList.tsx
@@ -265,7 +265,7 @@ const CommonUserList = ({
           style={{ cursor: 'pointer' }}
           onClick={() =>
             clickedPage !== 1 &&
-            handleClickPrevBtn({ clickedPage, setSearchParams })
+            handleClickPrevBtn({ clickedPage, sorting, setSearchParams })
           }
         />
         {pages.map((_, idx) => {
@@ -275,7 +275,7 @@ const CommonUserList = ({
               key={page}
               $isClicked={totalPage > 0 && clickedPage === page}
               onClick={() =>
-                handleClickPage({ clickedPage: page, setSearchParams })
+                handleClickPage({ clickedPage: page, sorting, setSearchParams })
               }
             >
               {page}
@@ -286,7 +286,7 @@ const CommonUserList = ({
           style={{ cursor: 'pointer' }}
           onClick={() =>
             clickedPage !== pages.length &&
-            handleClickNextBtn({ clickedPage, setSearchParams })
+            handleClickNextBtn({ clickedPage, sorting, setSearchParams })
           }
         />
       </PageNationBar>

--- a/src/common/Gnb.tsx
+++ b/src/common/Gnb.tsx
@@ -45,7 +45,7 @@ const Gnb = ({ category, handleOpenGnb }: GnbProps) => {
       case group[1]:
         return navigate('/group-new');
       case group[2]:
-        return navigate('/my-group?page=1&sort=NEW');
+        return navigate('/my-group?page=1&sort=NEW&status=ACTIVE');
       case profile[0]:
         return navigate(`/${username}`);
       case profile[1]:

--- a/src/common/Gnb.tsx
+++ b/src/common/Gnb.tsx
@@ -45,7 +45,7 @@ const Gnb = ({ category, handleOpenGnb }: GnbProps) => {
       case group[1]:
         return navigate('/group-new');
       case group[2]:
-        return navigate('/my-group?page=1');
+        return navigate('/my-group?page=1&sort=NEW');
       case profile[0]:
         return navigate(`/${username}`);
       case profile[1]:

--- a/src/common/Gnb.tsx
+++ b/src/common/Gnb.tsx
@@ -37,7 +37,9 @@ const Gnb = ({ category, handleOpenGnb }: GnbProps) => {
       case solve[0]:
         return navigate('/solve');
       case solve[1]:
-        return navigate(`/solution?page=1&year=${year}&month=${month}`);
+        return navigate(
+          `/solution?page=1&sort=NEW&year=${year}&month=${month}`
+        );
       case group[0]:
         return navigate('/group?page=1');
       case group[1]:

--- a/src/common/Groups.tsx
+++ b/src/common/Groups.tsx
@@ -13,6 +13,7 @@ import RecommendCard from './RecommendCard';
 const Groups = ({ group, totalPage }: PersonalGroupProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const clickedPage = Number(searchParams.get('page'));
+  const sorting = String(searchParams.get('sort'));
   const pages = Array.from(
     { length: totalPage > 0 ? totalPage : 1 },
     (_, idx) => idx + 1
@@ -26,7 +27,7 @@ const Groups = ({ group, totalPage }: PersonalGroupProps) => {
         <IcArrowLeftSmallGray
           onClick={() =>
             clickedPage > 1 &&
-            handleClickPrevBtn({ clickedPage, setSearchParams })
+            handleClickPrevBtn({ clickedPage, sorting, setSearchParams })
           }
         />
         {pages.map((page) => {
@@ -35,7 +36,7 @@ const Groups = ({ group, totalPage }: PersonalGroupProps) => {
               key={page}
               $isClicked={totalPage > 0 && clickedPage === page}
               onClick={() =>
-                handleClickPage({ clickedPage: page, setSearchParams })
+                handleClickPage({ clickedPage: page, sorting, setSearchParams })
               }
             >
               {page}
@@ -45,7 +46,7 @@ const Groups = ({ group, totalPage }: PersonalGroupProps) => {
         <IcArrowRightSmallGray
           onClick={() =>
             clickedPage !== totalPage &&
-            handleClickNextBtn({ clickedPage, setSearchParams })
+            handleClickNextBtn({ clickedPage, sorting, setSearchParams })
           }
         />
       </PageNationBar>

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -14,8 +14,6 @@ const RecommendCard = ({ group, isLongPage }: RecommendCardProps) => {
     isMember,
     isPublicRoom,
   }: ClickCardProps) => {
-    const queryStirng = location.search;
-    const clickedPage = Number(queryStirng.split('=')[1]);
     const myId = sessionStorage.getItem('user');
     const isOwner = myId && parseInt(myId) === userId;
     const navigatedPage = isPublicRoom ? `/group/${groupId}` : '/group-join';
@@ -24,10 +22,10 @@ const RecommendCard = ({ group, isLongPage }: RecommendCardProps) => {
       : { roomId: groupId.toString(), notNavigateDetail: true };
 
     if (isOwner) {
-      navigate(`/group/${groupId}/admin?page=${clickedPage}&sort=NEW`);
+      navigate(`/group/${groupId}/admin?page=1&sort=NEW`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member?page=${clickedPage}&sort=NEW`)
+        ? navigate(`/group/${groupId}/member?page=1&sort=NEW`)
         : navigate(navigatedPage, {
             state: navigatedState,
           });

--- a/src/common/RecommendCard.tsx
+++ b/src/common/RecommendCard.tsx
@@ -24,10 +24,10 @@ const RecommendCard = ({ group, isLongPage }: RecommendCardProps) => {
       : { roomId: groupId.toString(), notNavigateDetail: true };
 
     if (isOwner) {
-      navigate(`/group/${groupId}/admin?page=${clickedPage}`);
+      navigate(`/group/${groupId}/admin?page=${clickedPage}&sort=NEW`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member?page=${clickedPage}`)
+        ? navigate(`/group/${groupId}/member?page=${clickedPage}&sort=NEW`)
         : navigate(navigatedPage, {
             state: navigatedState,
           });

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -9,16 +9,15 @@ import Calendar from './Calendar';
 
 const ListFilter = ({
   sorting,
-  recentMonth,
   unsolvedMonths,
-  isUnsolvedDataLoading,
+  selectedMonth,
+  updateMonth,
   handleClickSorting,
 }: ListFilterProps) => {
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedYear = Number(searchParams.get('year'));
-  const selectedMonth = Number(searchParams.get('month'));
 
   const handleClickDateFilter = () => {
     setIsCalendarClicked(!isCalendarClicked);
@@ -29,9 +28,9 @@ const ListFilter = ({
 
     setSearchParams({
       page: '1',
-      sort: sorting,
+      sort: 'NEW',
       year: prevYear,
-      month: recentMonth.toString(),
+      month: selectedMonth.toString(),
     });
   };
 
@@ -40,6 +39,7 @@ const ListFilter = ({
   ) => {
     if (e) {
       const clickedMonth = e.currentTarget.innerHTML;
+      updateMonth(Number(clickedMonth));
       setSearchParams({
         page: '1',
         sort: sorting,
@@ -54,22 +54,20 @@ const ListFilter = ({
 
     setSearchParams({
       page: '1',
-      sort: sorting,
+      sort: 'NEW',
       year: nextYear,
-      month: recentMonth.toString(),
+      month: selectedMonth.toString(),
     });
   };
 
   useEffect(() => {
-    if (!isUnsolvedDataLoading) {
-      setSearchParams({
-        page: '1',
-        sort: 'NEW',
-        year: selectedYear.toString(),
-        month: recentMonth.toString(),
-      });
-    }
-  }, [recentMonth, isUnsolvedDataLoading]);
+    setSearchParams({
+      page: '1',
+      sort: sorting,
+      year: selectedYear.toString(),
+      month: selectedMonth.toString(),
+    });
+  }, [selectedMonth]);
 
   return (
     <FilteredContainer>

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -17,7 +17,6 @@ const ListFilter = ({
   const [isCalendarClicked, setIsCalendarClicked] = useState(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const page = String(searchParams.get('page'));
   const selectedYear = Number(searchParams.get('year'));
 
   const handleClickDateFilter = () => {

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { useSearchParams } from 'react-router-dom';
@@ -59,15 +59,6 @@ const ListFilter = ({
       month: selectedMonth.toString(),
     });
   };
-
-  useEffect(() => {
-    setSearchParams({
-      page: '1',
-      sort: sorting,
-      year: selectedYear.toString(),
-      month: selectedMonth.toString(),
-    });
-  }, [selectedMonth]);
 
   return (
     <FilteredContainer>

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -29,6 +29,7 @@ const ListFilter = ({
 
     setSearchParams({
       page: '1',
+      sort: sorting,
       year: prevYear,
       month: recentMonth.toString(),
     });
@@ -41,6 +42,7 @@ const ListFilter = ({
       const clickedMonth = e.currentTarget.innerHTML;
       setSearchParams({
         page: '1',
+        sort: sorting,
         year: selectedYear.toString(),
         month: clickedMonth,
       });
@@ -52,6 +54,7 @@ const ListFilter = ({
 
     setSearchParams({
       page: '1',
+      sort: sorting,
       year: nextYear,
       month: recentMonth.toString(),
     });
@@ -61,6 +64,7 @@ const ListFilter = ({
     if (!isUnsolvedDataLoading) {
       setSearchParams({
         page: '1',
+        sort: 'NEW',
         year: selectedYear.toString(),
         month: recentMonth.toString(),
       });
@@ -95,13 +99,14 @@ const ListFilter = ({
 
       <SortContainer>
         {OLD_AND_NEW.map((standard) => {
+          const clickedSort = sorting === 'NEW' ? '최신순' : '오래된순';
           return (
             <Sorting
               key={standard}
               onClick={(
                 e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
               ) => standard !== '|' && handleClickSorting(e)}
-              $isClicked={sorting === standard}
+              $isClicked={clickedSort === standard}
             >
               {standard}
             </Sorting>

--- a/src/common/SolutionList/ListFilter.tsx
+++ b/src/common/SolutionList/ListFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { useSearchParams } from 'react-router-dom';
@@ -18,6 +18,7 @@ const ListFilter = ({
 
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedYear = Number(searchParams.get('year'));
+  const curMonth = Number(searchParams.get('month'));
 
   const handleClickDateFilter = () => {
     setIsCalendarClicked(!isCalendarClicked);
@@ -59,6 +60,17 @@ const ListFilter = ({
       month: selectedMonth.toString(),
     });
   };
+
+  useEffect(() => {
+    if (selectedMonth !== curMonth) {
+      setSearchParams({
+        page: '1',
+        sort: 'NEW',
+        year: selectedYear.toString(),
+        month: selectedMonth.toString(),
+      });
+    }
+  }, [selectedYear, selectedMonth]);
 
   return (
     <FilteredContainer>

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -49,7 +49,8 @@ const SavedSolutionList = ({
     return 1;
   }, [isUnsolvedDataLoading, unsolvedMonths, selectedYear]);
 
-  const [selectedMonth, setSelectedMonth] = useState(recentMonth);
+  const initialMonth = isSmallList ? new Date().getMonth() + 1 : recentMonth;
+  const [selectedMonth, setSelectedMonth] = useState(initialMonth);
 
   const { data, isLoading: isRecordsLoading } = isSmallList
     ? useGetRecentFollowerRecords({ userId })

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -88,7 +88,12 @@ const SavedSolutionList = ({
     const prevPage = (clickedPage - 1).toString();
     const year = selectedYear.toString();
     const month = selectedMonth.toString();
-    setSearchParams({ page: prevPage, sort: 'NEW', year: year, month: month });
+    setSearchParams({
+      page: prevPage,
+      sort: sorting,
+      year: year,
+      month: month,
+    });
   };
 
   const handleClickPage = ({ clickedPage }: ClickedValueProps) => {
@@ -97,7 +102,7 @@ const SavedSolutionList = ({
     const month = selectedMonth.toString();
     setSearchParams({
       page: page.toString(),
-      sort: 'NEW',
+      sort: sorting,
       year: year,
       month: month,
     });
@@ -107,7 +112,12 @@ const SavedSolutionList = ({
     const nextPage = (clickedPage + 1).toString();
     const year = selectedYear.toString();
     const month = selectedMonth.toString();
-    setSearchParams({ page: nextPage, sort: 'NEW', year: year, month: month });
+    setSearchParams({
+      page: nextPage,
+      sort: sorting,
+      year: year,
+      month: month,
+    });
   };
 
   useEffect(() => {

--- a/src/common/SolutionList/SavedSolutionList.tsx
+++ b/src/common/SolutionList/SavedSolutionList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { IcArrowLeftSmallGray, IcArrowRightSmallGray } from '../../assets';
@@ -22,9 +22,9 @@ const SavedSolutionList = ({
   const isFollowerMode = myId && userId.toString() !== myId;
   const followerId = isFollowerMode ? userId : undefined;
 
-  const [sorting, setSorting] = useState('최신순');
   const [searchParams, setSearchParams] = useSearchParams();
   const clickedPage = isSmallList ? 0 : Number(searchParams.get('page'));
+  const sorting = isSmallList ? '' : String(searchParams.get('sort'));
   const selectedYear = isSmallList
     ? new Date().getFullYear()
     : Number(searchParams.get('year'));
@@ -77,28 +77,36 @@ const SavedSolutionList = ({
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
-    setSorting(innerHTML);
+    const sort = innerHTML === '최신순' ? 'NEW' : 'OLD';
+    const year = selectedYear.toString();
+    const month = selectedMonth.toString();
+    setSearchParams({ page: '1', sort: sort, year: year, month: month });
   };
 
   const handleClickPrevBtn = () => {
     const prevPage = (clickedPage - 1).toString();
     const year = selectedYear.toString();
     const month = selectedMonth.toString();
-    setSearchParams({ page: prevPage, year: year, month: month });
+    setSearchParams({ page: prevPage, sort: 'NEW', year: year, month: month });
   };
 
   const handleClickPage = ({ clickedPage }: ClickedValueProps) => {
     const page = clickedPage.toString();
     const year = selectedYear.toString();
     const month = selectedMonth.toString();
-    setSearchParams({ page: page.toString(), year: year, month: month });
+    setSearchParams({
+      page: page.toString(),
+      sort: 'NEW',
+      year: year,
+      month: month,
+    });
   };
 
   const handleClickNextBtn = () => {
     const nextPage = (clickedPage + 1).toString();
     const year = selectedYear.toString();
     const month = selectedMonth.toString();
-    setSearchParams({ page: nextPage, year: year, month: month });
+    setSearchParams({ page: nextPage, sort: 'NEW', year: year, month: month });
   };
 
   useEffect(() => {

--- a/src/components/Admin/AdminMemberList.tsx
+++ b/src/components/Admin/AdminMemberList.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonUserList from '../../common/CommonUserList';
 import MemberHeader from '../GroupMember/MemberHeader';
@@ -9,14 +9,17 @@ const AdminMemberList = () => {
   if (!id) return;
   const groupId = parseInt(id);
 
-  const [sorting, setSorting] = useState('최신순');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sorting = String(searchParams.get('sort'));
 
   const handleClickSorting = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
-    setSorting(innerHTML);
+    const sort = innerHTML === '최신순' ? 'NEW' : 'DICT';
+    setSearchParams({ page: '1', sort: sort });
   };
+
   return (
     <AdminListContainer>
       <MemberHeader

--- a/src/components/Follower/Current/FollowerFilter.tsx
+++ b/src/components/Follower/Current/FollowerFilter.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcArrowBottomGray, IcArrowTopGray } from '../../../assets';
 import { SORTING } from '../../../constants/Follower/currentConst';
@@ -12,6 +13,8 @@ const FollowerFilter = ({
 }: FollowerFilterProps) => {
   const [isGroupClicked, setIsGroupClicked] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState('');
+
+  const [_, setSearchParams] = useSearchParams();
 
   const { data, isLoading } = useGetJoinedGroupList();
   const { joinedRooms } = !isLoading && data?.data;
@@ -28,6 +31,7 @@ const FollowerFilter = ({
       setSelectedGroup(innerHTML);
       updateSelectedGroupId(id);
     }
+    setSearchParams({ page: '1', sort: 'NEW' });
   };
 
   const handleClickGroupFilter = () => {
@@ -68,13 +72,14 @@ const FollowerFilter = ({
 
       <SortContainer>
         {SORTING.map((standard) => {
+          const clickedSort = sorting === 'NEW' ? '최신순' : '가나다순';
           return (
             <Sorting
               key={standard}
               onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
                 standard !== '|' && handleClickSorting(e)
               }
-              $isClicked={sorting === standard}
+              $isClicked={clickedSort === standard}
             >
               {standard}
             </Sorting>

--- a/src/components/Follower/Current/FollowerList.tsx
+++ b/src/components/Follower/Current/FollowerList.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonUserList from '../../../common/CommonUserList';
 import FollowerFilter from './FollowerFilter';
 
 const FollowerList = () => {
   const [selectedGroupId, setSelectedGroupId] = useState(0);
-  const [sorting, setSorting] = useState('최신순');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sorting = String(searchParams.get('sort'));
 
   const updateSelectedGroupId = (id: number) => {
     setSelectedGroupId(id);
@@ -15,7 +17,8 @@ const FollowerList = () => {
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
-    setSorting(innerHTML);
+    const sort = innerHTML === '최신순' ? 'NEW' : 'DICT';
+    setSearchParams({ page: '1', sort: sort });
   };
 
   return (

--- a/src/components/Follower/Personal/ParticipatingGroup.tsx
+++ b/src/components/Follower/Personal/ParticipatingGroup.tsx
@@ -30,10 +30,10 @@ const ParticipatingGroup = ({ nickname }: ParticipatingGroupProps) => {
   }: ClickCardProps) => {
     const myId = sessionStorage.getItem('user');
     if (myId && parseInt(myId) === userId) {
-      navigate(`/group/${groupId}/admin?page=1`);
+      navigate(`/group/${groupId}/admin?page=1&sort=NEW`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member?page=1`)
+        ? navigate(`/group/${groupId}/member?page=1&sort=NEW`)
         : navigate(`/group/${groupId}`, {
             state: { isPublicRoom: isPublicRoom },
           });

--- a/src/components/Follower/Personal/ParticipatingGroup.tsx
+++ b/src/components/Follower/Personal/ParticipatingGroup.tsx
@@ -18,7 +18,7 @@ const ParticipatingGroup = ({ nickname }: ParticipatingGroupProps) => {
   const { data, isLoading } = useGetRooms({
     followerId: followerId,
     isJoinedRooms: true,
-    sortType: '최신순',
+    sortType: 'NEW',
   });
   const { joinedRooms } = !isLoading && data?.data;
 

--- a/src/components/Follower/Personal/Solutions.tsx
+++ b/src/components/Follower/Personal/Solutions.tsx
@@ -18,7 +18,9 @@ const Solutions = ({ id, nickname }: SolutionsProps) => {
 
   const handleClickMoreBtn = () => {
     sessionStorage.setItem('friendname', nickname);
-    navigate(`/follower/${id}/total?page=1&year=${year}&month=${month}`);
+    navigate(
+      `/follower/${id}/total?page=1&sort=NEW&year=${year}&month=${month}`
+    );
   };
 
   return (

--- a/src/components/GroupMember/MemberHeader.tsx
+++ b/src/components/GroupMember/MemberHeader.tsx
@@ -15,13 +15,14 @@ const MemberHeader = ({
       <Title>{title}</Title>
       <SortContainer>
         {sortingFilter.map((standard) => {
+          const clickedSort = sorting === 'NEW' ? '최신순' : '가나다순';
           return (
             <Sorting
               key={standard}
               onClick={(
                 e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
               ) => standard !== '|' && handleClickSorting(e)}
-              $isClicked={sorting === standard}
+              $isClicked={clickedSort === standard}
             >
               {standard}
             </Sorting>

--- a/src/components/GroupMember/MemberList.tsx
+++ b/src/components/GroupMember/MemberList.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonUserList from '../../common/CommonUserList';
 import MemberHeader from './MemberHeader';
@@ -9,13 +9,15 @@ const MemberList = () => {
   if (!id) return;
   const groupId = parseInt(id);
 
-  const [sorting, setSorting] = useState('최신순');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sorting = String(searchParams.get('sort'));
 
   const handleClickSorting = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => {
     const { innerHTML } = e.currentTarget;
-    setSorting(innerHTML);
+    const sort = innerHTML === '최신순' ? 'NEW' : 'DICT';
+    setSearchParams({ page: '1', sort: sort });
   };
 
   return (

--- a/src/components/Home/WeekFollowing/WeeklyFollower.tsx
+++ b/src/components/Home/WeekFollowing/WeeklyFollower.tsx
@@ -16,7 +16,7 @@ const WeeklyFollower = () => {
   const hasFollowers = !isLoading && followings.length > 0;
 
   const handleClickAllButton = () => {
-    navigate('/follower?page=1');
+    navigate('/follower?page=1&sort=NEW');
   };
 
   while (!isLoading && followings.length < 3) {

--- a/src/components/MyGroup/ActiveGroups.tsx
+++ b/src/components/MyGroup/ActiveGroups.tsx
@@ -42,10 +42,10 @@ const ActiveGroups = ({ totalActiveGroups }: ActiveGroupProps) => {
   }: ClickCardProps) => {
     const myId = sessionStorage.getItem('user');
     if (myId && parseInt(myId) === userId) {
-      navigate(`/group/${groupId}/admin?page=1`);
+      navigate(`/group/${groupId}/admin?page=1&sort=NEW`);
     } else {
       isMember
-        ? navigate(`/group/${groupId}/member?page=1`)
+        ? navigate(`/group/${groupId}/member?page=1&sort=NEW`)
         : navigate(`/group/${groupId}`, {
             state: { isPublicRoom: isPublicRoom },
           });

--- a/src/components/MyGroup/PersonalGroup.tsx
+++ b/src/components/MyGroup/PersonalGroup.tsx
@@ -18,25 +18,17 @@ const PersonalGroup = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const clickedPage = Number(searchParams.get('page'));
   const sorting = String(searchParams.get('sort'));
+  const status = String(searchParams.get('status'));
 
   const [clickedCategry, setClickedCategory] = useState(
     savedCategory ? savedCategory : GROUP_CATEGORY[0]
   );
-  const [filter, setFilter] = useState({
-    clickedStatus: '모집 중',
-  });
   const isJoinedRooms = clickedCategry === GROUP_CATEGORY[0];
 
-  const { clickedStatus } = filter;
   const { data, isLoading } = useGetRooms({
     sortType: sorting,
     page: clickedPage - 1,
-    status:
-      clickedStatus === '모집 중'
-        ? 'ACTIVE'
-        : clickedStatus === '모집 마감'
-          ? 'INACTIVE'
-          : 'CLOSED',
+    status,
     isJoinedRooms: isJoinedRooms,
   });
   const successData = !isLoading && data.data;
@@ -51,13 +43,16 @@ const PersonalGroup = () => {
   ) => {
     const { innerText } = e.currentTarget;
     const sort = innerText === '최신순' ? 'NEW' : 'DICT';
+    const clickedStatus =
+      innerText === '모집 중'
+        ? 'ACTIVE'
+        : innerText === '모집 마감'
+          ? 'INACTIVE'
+          : 'CLOSED';
 
     isSorting
-      ? setSearchParams({ page: '1', sort: sort })
-      : setFilter({
-          ...filter,
-          clickedStatus: innerText,
-        });
+      ? setSearchParams({ page: '1', sort: sort, status: 'ACTIVE' })
+      : setSearchParams({ page: '1', sort: 'NEW', status: clickedStatus });
   };
 
   const handleClickCategory = (
@@ -67,7 +62,7 @@ const PersonalGroup = () => {
     setClickedCategory(innerHTML);
     sessionStorage.setItem('savedCategory', innerHTML);
 
-    setSearchParams({ page: '1', sort: 'NEW' });
+    setSearchParams({ page: '1', sort: 'NEW', status: 'ACTIVE' });
   };
 
   return (
@@ -88,18 +83,29 @@ const PersonalGroup = () => {
 
       <TopContainer>
         <TotalStatus>
-          {STATUS.map((status, idx) => {
+          {STATUS.map((curStatus, idx) => {
+            const clickedStatus =
+              status === 'ACTIVE'
+                ? '모집 중'
+                : status === 'INACTIVE'
+                  ? '모집 마감'
+                  : '활동 종료';
+
             return (
               <StatusContainer
-                key={status}
+                key={curStatus}
                 type="button"
                 onClick={(e) => handleClickSorting(e, false)}
               >
-                {clickedStatus === status ? <IcSuccess /> : <IcSuccessGray />}
+                {clickedStatus === curStatus ? (
+                  <IcSuccess />
+                ) : (
+                  <IcSuccessGray />
+                )}
 
                 <Status $idx={idx}>
                   {idx === 0 ? <IcStatusBlack /> : <IcStatusWhite />}
-                  <Text $idx={idx}>{status}</Text>
+                  <Text $idx={idx}>{curStatus}</Text>
                 </Status>
               </StatusContainer>
             );

--- a/src/components/MyGroup/PersonalGroup.tsx
+++ b/src/components/MyGroup/PersonalGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import {
@@ -42,10 +42,6 @@ const PersonalGroup = () => {
   const successData = !isLoading && data.data;
   const { totalPage, joinedRooms, createdRooms } = successData;
   const group = isJoinedRooms ? joinedRooms : createdRooms;
-
-  useEffect(() => {
-    sessionStorage.removeItem('savedPage');
-  }, []);
 
   const handleClickSorting = (
     e:

--- a/src/components/MyGroup/PersonalGroup.tsx
+++ b/src/components/MyGroup/PersonalGroup.tsx
@@ -17,17 +17,17 @@ const PersonalGroup = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const clickedPage = Number(searchParams.get('page'));
+  const sorting = String(searchParams.get('sort'));
 
   const [clickedCategry, setClickedCategory] = useState(
     savedCategory ? savedCategory : GROUP_CATEGORY[0]
   );
   const [filter, setFilter] = useState({
     clickedStatus: '모집 중',
-    sorting: '최신순',
   });
   const isJoinedRooms = clickedCategry === GROUP_CATEGORY[0];
 
-  const { clickedStatus, sorting } = filter;
+  const { clickedStatus } = filter;
   const { data, isLoading } = useGetRooms({
     sortType: sorting,
     page: clickedPage - 1,
@@ -50,17 +50,14 @@ const PersonalGroup = () => {
     isSorting: boolean
   ) => {
     const { innerText } = e.currentTarget;
+    const sort = innerText === '최신순' ? 'NEW' : 'DICT';
 
     isSorting
-      ? setFilter({
-          ...filter,
-          sorting: innerText,
-        })
+      ? setSearchParams({ page: '1', sort: sort })
       : setFilter({
           ...filter,
           clickedStatus: innerText,
         });
-    // 최신순/ 가나다순에 따라 서버 통신 들어갈 예정
   };
 
   const handleClickCategory = (
@@ -70,7 +67,7 @@ const PersonalGroup = () => {
     setClickedCategory(innerHTML);
     sessionStorage.setItem('savedCategory', innerHTML);
 
-    setSearchParams({ page: '1' });
+    setSearchParams({ page: '1', sort: 'NEW' });
   };
 
   return (
@@ -111,11 +108,12 @@ const PersonalGroup = () => {
 
         <SortContainer>
           {SORTING.map((standard) => {
+            const clickedSort = sorting === 'NEW' ? '최신순' : '가나다순';
             return (
               <Sorting
                 key={standard}
                 onClick={(e) => standard !== '|' && handleClickSorting(e, true)}
-                $isClicked={sorting === standard}
+                $isClicked={clickedSort === standard}
               >
                 {standard}
               </Sorting>

--- a/src/libs/apis/Admin/getParticipantsList.ts
+++ b/src/libs/apis/Admin/getParticipantsList.ts
@@ -7,7 +7,7 @@ const getParticipantsList = async ({
   page,
 }: GetMemberListProps) => {
   const { data } = await api.get(
-    `/rooms/${groupId}/participants/${sortType === '최신순' ? 'NEW' : 'OLD'}?page=${page}`
+    `/rooms/${groupId}/participants/${sortType}?page=${page}`
   );
 
   return data;

--- a/src/libs/apis/Follower/getFollowerSummary.ts
+++ b/src/libs/apis/Follower/getFollowerSummary.ts
@@ -7,8 +7,8 @@ const getFollowerSummary = async ({
   page,
 }: GetFollowerSummaryProps) => {
   const isActiveGroupId = groupId && groupId > 0;
-  const followerList = `/follow/followings/summary/${sortType === '최신순' ? `NEW` : `DICT`}?page=${page}`;
-  const memberList = `/follow/followings/summary/${sortType === '최신순' ? `NEW` : `DICT`}?page=${page}${groupId && `&roomId=${groupId}`}`;
+  const followerList = `/follow/followings/summary/${sortType}?page=${page}`;
+  const memberList = `/follow/followings/summary/${sortType}?page=${page}${groupId && `&roomId=${groupId}`}`;
   const { data } = isActiveGroupId
     ? await api.get(memberList)
     : await api.get(followerList);

--- a/src/libs/apis/GroupMember/getMeberList.ts
+++ b/src/libs/apis/GroupMember/getMeberList.ts
@@ -7,7 +7,7 @@ const getMeberList = async ({
   page,
 }: GetMemberListProps) => {
   const { data } = await api.get(
-    `/rooms/${groupId}/members/${sortType === '최신순' ? 'NEW' : 'DICT'}?page=${page}`
+    `/rooms/${groupId}/members/${sortType}?page=${page}`
   );
 
   return data;

--- a/src/libs/apis/Solution/getMonthlySolution.ts
+++ b/src/libs/apis/Solution/getMonthlySolution.ts
@@ -11,7 +11,7 @@ export const getMonthlySolution = async ({
   const isCorrectMonth = typeof month === 'number';
   const formatMonth = isCorrectMonth && (month < 10 ? `0${month}` : `${month}`);
   const { data } = await api.get(
-    `/records/${userId}/month/${sortType === '오래된순' ? 'OLD' : 'NEW'}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=7`
+    `/records/${userId}/month/${sortType}?pivotDate=${year}-${formatMonth}-01&page=${page}&size=7`
   );
 
   return data;

--- a/src/libs/apis/utils/getRooms.ts
+++ b/src/libs/apis/utils/getRooms.ts
@@ -10,7 +10,7 @@ const getRooms = async ({
 }: GetRoomsProps) => {
   const user = sessionStorage.getItem('user');
   const { data } = await api.get(
-    `/rooms/${followerId ? followerId : user}/${isJoinedRooms ? 'member' : 'owner'}/${sortType === '최신순' ? 'NEW' : 'DICT'}${page !== undefined ? `?page=${page}` : ''}${status ? `&status=${status}` : ''}`
+    `/rooms/${followerId ? followerId : user}/${isJoinedRooms ? 'member' : 'owner'}/${sortType}${page !== undefined ? `?page=${page}` : ''}${status ? `&status=${status}` : ''}`
   );
 
   return data;

--- a/src/libs/hooks/Alarm/usePostAlarmRead.ts
+++ b/src/libs/hooks/Alarm/usePostAlarmRead.ts
@@ -26,10 +26,10 @@ const usePostAlarmRead = () => {
           navigate(`/follower/${dataId}`);
           break;
         case 'CREATED_PUBLIC_ROOM_REQUEST':
-          navigate(`/group/${dataId}/admin?page=1`);
+          navigate(`/group/${dataId}/admin?page=1&sort=NEW`);
           break;
         case 'CREATED_PRIVATE_ROOM_JOIN':
-          navigate(`/group/${dataId}/admin?page=1`);
+          navigate(`/group/${dataId}/admin?page=1&sort=NEW`);
           break;
         case 'PUBLIC_ROOM_REQUEST':
           navigate(`/group/${dataId}`, {
@@ -37,10 +37,10 @@ const usePostAlarmRead = () => {
           }); // state 를 true로 변경하여 신청하기 버튼 없애기
           break;
         case 'PUBLIC_ROOM_APPROVE':
-          navigate(`/group/${dataId}/member?page=1`);
+          navigate(`/group/${dataId}/member?page=1&sort=NEW`);
           break;
         case 'ROOM_STATUS_INACTIVE':
-          navigate('/my-group?page=1');
+          navigate('/my-group?page=1&sort=NEW&status=ACTIVE');
           break;
       }
       queryClient.invalidateQueries({ queryKey: ['get-alarm-read'] });

--- a/src/libs/hooks/GroupEdit/usePatchRooms.ts
+++ b/src/libs/hooks/GroupEdit/usePatchRooms.ts
@@ -21,7 +21,7 @@ const usePatchRooms = () => {
       // roomId를 queryKey와 navigate에 사용
       queryClient.invalidateQueries({ queryKey: ['get-detail', roomId] });
       queryClient.invalidateQueries({ queryKey: ['get-rooms-id'] });
-      navigate(`/group/${roomId}/admin?page=1`);
+      navigate(`/group/${roomId}/admin?page=1&sort=NEW`);
     },
     onError: (err: any) => {
       const message = err?.response?.data?.message || 'Something went wrong';

--- a/src/libs/hooks/GroupJoin/usePostAnswer.ts
+++ b/src/libs/hooks/GroupJoin/usePostAnswer.ts
@@ -9,7 +9,7 @@ const usePostAnswer = (roomId: number) => {
     mutationFn: async ({ roomId, password }: PostAnswerProps) =>
       await postAnswer({ roomId, password }),
     onSuccess: () => {
-      navigate(`/group/${roomId}/member?page=1`);
+      navigate(`/group/${roomId}/member?page=1&sort=NEW`);
     },
     onError: (err: { response: { data: { message: string } } }) => {
       const { message } = err.response.data;

--- a/src/libs/hooks/Solution/useDeleteRecords.ts
+++ b/src/libs/hooks/Solution/useDeleteRecords.ts
@@ -16,7 +16,7 @@ const useDeleteRecords = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['get-monthly-solution'] });
-      navigate('/solution?page=1');
+      navigate('/solution?page=1&sort=NEW');
     },
   });
 

--- a/src/libs/hooks/Solve/usePostRecords.ts
+++ b/src/libs/hooks/Solve/usePostRecords.ts
@@ -28,7 +28,7 @@ const usePostRecords = ({
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['get-monthly-solution'] });
         queryClient.invalidateQueries({ queryKey: ['get-temp-records'] });
-        navigate(`/solution?page=1`);
+        navigate(`/solution?page=1&sort=NEW`);
       }, 1500);
     },
   });

--- a/src/libs/hooks/Solve/usePostTempRecords.ts
+++ b/src/libs/hooks/Solve/usePostTempRecords.ts
@@ -20,7 +20,7 @@ const usePostTempRecords = (onClose?: () => void) => {
     onSuccess: ({ data }) => {
       if (data) {
         queryClient.invalidateQueries({ queryKey: ['get-temp-records'] });
-        navigate('/solution?page=1');
+        navigate('/solution?page=1&sort=NEW');
         onClose && onClose();
       }
     },

--- a/src/page/GroupComplete.tsx
+++ b/src/page/GroupComplete.tsx
@@ -51,7 +51,7 @@ const GroupComplete = () => {
   const handleGroupPageRedirect = async () => {
     if (token && nickname) {
       const data = await getGroupInfo(uuid!);
-      navigate(`/group/${data.roomId}/admin?page=1`);
+      navigate(`/group/${data.roomId}/admin?page=1&sort=NEW`);
     }
   };
 

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -130,7 +130,7 @@ const GroupEdit = () => {
     setSelectedTags(tags || []);
     setIsPublicGroup(!password);
     setSelectedImageFile(null);
-    navigate(`/group/${id}/admin?page=1`);
+    navigate(`/group/${id}/admin?page=1&sort=NEW`);
   };
 
   useEffect(() => {

--- a/src/types/Solution/solutionTypes.ts
+++ b/src/types/Solution/solutionTypes.ts
@@ -102,9 +102,9 @@ export interface ClickedValueProps {
 
 export interface ListFilterProps {
   sorting: string;
-  recentMonth: number;
   unsolvedMonths: Array<number>;
-  isUnsolvedDataLoading: boolean;
+  selectedMonth: number;
+  updateMonth: (month: number) => void;
   handleClickSorting: (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>
   ) => void;

--- a/src/utils/handleClickPage.ts
+++ b/src/utils/handleClickPage.ts
@@ -12,7 +12,10 @@ export const handleClickPrevBtn = ({
   setSearchParams,
 }: clickedPageType) => {
   const prevPage = (clickedPage - 1).toString();
-  setSearchParams({ page: prevPage, sort: sorting });
+
+  sorting === null
+    ? setSearchParams({ page: prevPage })
+    : setSearchParams({ page: prevPage, sort: sorting });
 };
 
 export const handleClickPage = ({
@@ -20,7 +23,10 @@ export const handleClickPage = ({
   sorting,
   setSearchParams,
 }: clickedPageType) => {
-  setSearchParams({ page: clickedPage.toString(), sort: sorting });
+  const page = clickedPage.toString();
+  sorting === null
+    ? setSearchParams({ page })
+    : setSearchParams({ page, sort: sorting });
 };
 
 export const handleClickNextBtn = ({
@@ -29,5 +35,7 @@ export const handleClickNextBtn = ({
   setSearchParams,
 }: clickedPageType) => {
   const nextPage = (clickedPage + 1).toString();
-  setSearchParams({ page: nextPage, sort: sorting });
+  sorting === null
+    ? setSearchParams({ page: nextPage })
+    : setSearchParams({ page: nextPage, sort: sorting });
 };

--- a/src/utils/handleClickPage.ts
+++ b/src/utils/handleClickPage.ts
@@ -2,28 +2,32 @@ import { SetURLSearchParams } from 'react-router-dom';
 
 type clickedPageType = {
   clickedPage: number;
+  sorting: string;
   setSearchParams: SetURLSearchParams;
 };
 
 export const handleClickPrevBtn = ({
   clickedPage,
+  sorting,
   setSearchParams,
 }: clickedPageType) => {
   const prevPage = (clickedPage - 1).toString();
-  setSearchParams({ page: prevPage });
+  setSearchParams({ page: prevPage, sort: sorting });
 };
 
 export const handleClickPage = ({
   clickedPage,
+  sorting,
   setSearchParams,
 }: clickedPageType) => {
-  setSearchParams({ page: clickedPage.toString() });
+  setSearchParams({ page: clickedPage.toString(), sort: sorting });
 };
 
 export const handleClickNextBtn = ({
   clickedPage,
+  sorting,
   setSearchParams,
 }: clickedPageType) => {
   const nextPage = (clickedPage + 1).toString();
-  setSearchParams({ page: nextPage });
+  setSearchParams({ page: nextPage, sort: sorting });
 };

--- a/src/utils/handleClickPage.ts
+++ b/src/utils/handleClickPage.ts
@@ -6,16 +6,26 @@ type clickedPageType = {
   setSearchParams: SetURLSearchParams;
 };
 
+const updateParams = ({
+  clickedPage,
+  sorting,
+  setSearchParams,
+}: clickedPageType) => {
+  const page = clickedPage.toString();
+
+  // sorting이 null이거나 undefined인 경우 false로 처리
+  sorting?.trim()
+    ? setSearchParams({ page, sort: sorting })
+    : setSearchParams({ page });
+};
+
 export const handleClickPrevBtn = ({
   clickedPage,
   sorting,
   setSearchParams,
 }: clickedPageType) => {
-  const prevPage = (clickedPage - 1).toString();
-
-  sorting === null
-    ? setSearchParams({ page: prevPage })
-    : setSearchParams({ page: prevPage, sort: sorting });
+  const prevPage = clickedPage - 1;
+  updateParams({ clickedPage: prevPage, sorting, setSearchParams });
 };
 
 export const handleClickPage = ({
@@ -23,10 +33,7 @@ export const handleClickPage = ({
   sorting,
   setSearchParams,
 }: clickedPageType) => {
-  const page = clickedPage.toString();
-  sorting === null
-    ? setSearchParams({ page })
-    : setSearchParams({ page, sort: sorting });
+  updateParams({ clickedPage, sorting, setSearchParams });
 };
 
 export const handleClickNextBtn = ({
@@ -34,8 +41,6 @@ export const handleClickNextBtn = ({
   sorting,
   setSearchParams,
 }: clickedPageType) => {
-  const nextPage = (clickedPage + 1).toString();
-  sorting === null
-    ? setSearchParams({ page: nextPage })
-    : setSearchParams({ page: nextPage, sort: sorting });
+  const nextPage = clickedPage + 1;
+  updateParams({ clickedPage: nextPage, sorting, setSearchParams });
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #363 

## ✅ 작업 내용

- [x] 선택된 정렬(최신순 / 가나다순 / 오래된 순)이 뒤로 가기로 돌아왔을 때에도 유지되도록 구현
- [x] 필터링(정렬, 날짜) 선택 시 한 번에 반영되지 이슈 문제 해결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/61b7f34c-8fff-45d4-aca1-ef4ecb5350a8


## 📌 이슈 사항
**1. 선택된 정렬(최신순 / 가나다순 / 오래된 순)이 뒤로 가기로 돌아왔을 때에도 유지되도록 구현**
앞선 기능 구현처럼 query parameter를 활용해서 구현했어요. 페이지에 처음 접근했을 때는 query parameter가 없다가 정렬을 바꿨을 때만 query parameter가 생성되는 방식은 일관되지 않아 어색하게 느껴졌어요. 따라서 정렬 또한 초기 path에 query parameter를 적용하여 ux 일관성을 유지했어요.
navigate path를 변경하느라 file changed가 많아졌는데, 앞서 구현했던 내용과 거의 유사하기 때문에 어떤 식으로 구현했는지 정도만 확인해주셔도 될 것 같아요!

<br />

**2. 필터링(정렬, 날짜) 선택 시 한 번에 반영되지 이슈 문제 해결**
기존 코드에서는 필터링을 걸었을 때 리렌더링이 한 번 발생할 뿐 선택한 필터에 맞는 내용이 렌더되지 않았고, 다시 필터링을 걸어줘야 제대로 반영되는 이슈가 있었어요. 코드를 확인해보니 선택한 날짜를 url에 반영하기 위해 useEffect를 실행시킨 부분이 문제였어요. (`src > common > SolutionList > ListFilter.tsx`)

가장 최근 문제를 푼 달(recentMonth)과 문제를 풀지 않은 달 정보의 loading 여부(isUnsolvedDataLoading)를 의존성에 추가하고, 로딩 중이 아니라면(!isUnsolvedDataLoading) url을 변경했었어요. 
```typescript
// 기존 코드
useEffect(() => {
    if (!isUnsolvedDataLoading) {
      setSearchParams({
        page: '1',
        sort: 'NEW',
        year: selectedYear.toString(),
        month: recentMonth.toString(),
      });
    }
  }, [recentMonth, isUnsolvedDataLoading]);
```

여기서 문제는 년도를 변경했을 때(의도함) + 년도를 변경하지 않고 달(month)만 변경했을 때(의도하지 않음) 모두 위의 코드가 실행된다는 것이었어요. 예를 들어, 3월 -> 2월로 변경했을 때 useEffect가 실행되어 3월이 띄워진 페이지에서 리렌더링이 한 번 발생하고 선택한 달이 반영되지는 않았어요.

이를 해결하기 위해 상위 컴포넌트(`src > common > SolutionList > SavedSolutionList.tsx`)에서 selectedMonth를 상태로 정의하고, 초기값으로 recentMonth를 할당했어요. 그리고 년도 값이 바뀔 때마다 selectedMonth 값을 최신 recentMonth로 바꿔주었어요.
날짜 필터링을 관리하는 ListFilter 컴포넌트에서는 selectedMonth를 props로 받아오고, 달이 변경된 경우에는 selectedMonth를 선택한 달로 바꿔주었어요.
또한, 년도가 바뀌었을 때 기존에 선택했던 '오래된 순'이 유지되는 것은 조금 어색하게 느껴져서, 년도 변경 시 정렬을 '최신순'으로 초기해요!

<br />

**3. 페이지 클릭 함수 내부 로직 유틸화**
페이지 클릭 함수 자체를 util로 분리해두었는데, 다시 보니까 clickPrevBtn, clickNextBtn, clickPage 함수가 거의 동일한 구조로 구현되어 있었어요. 중복된 코드를 줄이고 재사용성을 높이기 위해, 공통 로직를 updateParams라는 공통 함수로 분리, 유틸화해주었어요.
```typescript
const updateParams = ({
  clickedPage,
  sorting,
  setSearchParams,
}: clickedPageType) => {
  const page = clickedPage.toString();

  // sorting이 null이거나 undefined인 경우 false로 처리
  sorting?.trim()
    ? setSearchParams({ page, sort: sorting })
    : setSearchParams({ page });
};

export const handleClickPage = ({
  clickedPage,
  sorting,
  setSearchParams,
}: clickedPageType) => {
  updateParams({ clickedPage, sorting, setSearchParams });
};

...
```

<br />

## ✍ 궁금한 것
useEffect는 컴포넌트가 마운트된 후 실행되기 때문에, 내부에서 setState를 호출하면 `컴포넌트 마운트 → useEffect 실행 → 리렌더링` 과정이 발생해요. 따라서 useEffect 내부에서 setState를 호출하는 구조는 가능하면 지양하고자 해요.
그런데 년도(selectedYear)가 변경될 때 selectedMonth에 최신 recentMonth 정보를 반영하는 적절한 방법이 떠오르지 않아, 해당 방식으로 구현하게 됐어요. 최대한 불필요한 렌더링을 방지하기 위해 recentMonth를 useMemo 형태로 구현했지만, 이게 최선은 아닌 것 같아 고민이 되네요 ,,

로직을 변경하더라도 최대한 위와 같은 구조는 피하고 싶은데, 날짜 필터링을 걸었을 때 지금처럼 동작하게 하는 다른 방법을 찾지 못했어요,,ㅠ
혹시 괜찮은 방법이 있다면 의견 부탁드립니다아 !!ㅠ_ㅠ

➡️ useEffect는 공식문서에도 `외부 시스템과의 동기화를 위해 사용한다`고 나와있어요. 현재 useEffect에서는 서버에서 받아온 unsolvedData 기반으로 recentMonth를 계산하고 이를 상태 값으로 업데이트하고 있기 때문에, 공식 문서에서 정의한 사용 방식과 맞는다고 판단했어요. 따라서 위의 코드는 따로 수정하지 않고 머지할게요!

또, 전에 얘기했던 것처럼 배포한 사이트에서 제대로 동작하지 않는 부분을 개선한 것이기도 해서, 먼저 머지하면 시간될 때 리뷰 부탁드려요!
