### PR TITLE
[ SP2 ] 이미지 리사이징

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/event-source-polyfill": "^1.0.5",
     "@uiw/react-codemirror": "^4.23.0",
     "axios": "^1.7.2",
+    "browser-image-compression": "^2.0.2",
     "codemirror": "^6.0.1",
     "event-source-polyfill": "^1.0.31",
     "framer-motion": "^11.11.17",

--- a/src/components/GroupCreate/ImageSection.tsx
+++ b/src/components/GroupCreate/ImageSection.tsx
@@ -19,7 +19,7 @@ const ImageSection = ({
         <TooltipInfo
           isVisible={isTooltipVisible}
           onClick={handleTooltipClose}
-          text="이미지는 최대 10MB까지 업로드 가능해요"
+          text="이미지는 최대 5MB까지 업로드 가능해요"
         />
       </LabelContainer>
       <ImageContainer

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -61,7 +61,7 @@ const GroupCreate = () => {
 
     const options = {
       maxSizeMB: 1,
-      maxWidthOrHeight: 445,
+      maxWidthOrHeight: 297,
       useWebWorker: true,
     };
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -59,6 +59,12 @@ const GroupCreate = () => {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    const maxFileSizeMB = 5;
+    if (file.size > maxFileSizeMB * 1024 * 1024) {
+      e.target.value = ''; // 파일 입력 필드 초기화
+      return;
+    }
+
     const options = {
       maxSizeMB: 0.5,
       maxWidthOrHeight: 1224,

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -57,17 +57,24 @@ const GroupCreate = () => {
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files ? e.target.files[0] : null;
-    console.log(file);
+
     // 이미지 압축 옵션 설정
     const options = {
       maxSizeMB: 1,
       maxWidthOrHeight: 445,
-      useWebWorker: true, // Web Worker 사용
+      useWebWorker: true,
     };
     if (file) {
       try {
         // 이미지 압축 (비동기)
-        const compressedFile = await imageCompression(file, options);
+        const compressedBlob = await imageCompression(file, options);
+
+        // Blob을 File로 변환
+        const compressedFile = new File([compressedBlob], file.name, {
+          type: file.type,
+          lastModified: Date.now(),
+        });
+
         setSelctedImageFIle(compressedFile);
 
         // 미리보기 이미지 생성

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -56,39 +56,34 @@ const GroupCreate = () => {
   };
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files ? e.target.files[0] : null;
+    const file = e.target.files?.[0];
+    if (!file) return;
 
-    // 이미지 압축 옵션 설정
     const options = {
       maxSizeMB: 1,
       maxWidthOrHeight: 445,
       useWebWorker: true,
     };
-    if (file) {
-      try {
-        // 이미지 압축 (비동기)
-        const compressedBlob = await imageCompression(file, options);
 
-        // Blob을 File로 변환
-        const compressedFile = new File([compressedBlob], file.name, {
-          type: file.type,
-          lastModified: Date.now(),
-        });
+    try {
+      // 이미지 압축
+      const compressedBlob = await imageCompression(file, options);
+      const compressedFile = new File([compressedBlob], file.name, {
+        type: file.type,
+        lastModified: Date.now(),
+      });
 
-        setSelctedImageFIle(compressedFile);
+      setSelctedImageFIle(compressedFile);
 
-        // 미리보기 이미지 생성
-        const reader = new FileReader();
-        reader.onload = () => {
-          setPreviewImage(reader.result as string);
-        };
-        reader.readAsDataURL(compressedFile);
+      // 미리보기 이미지 생성
+      const reader = new FileReader();
+      reader.onload = () => setPreviewImage(reader.result as string);
+      reader.readAsDataURL(compressedFile);
 
-        // 파일 입력 필드 초기화
-        e.target.value = '';
-      } catch (error) {
-        console.error('이미지 압축 중 오류 발생:', error);
-      }
+      // 파일 입력 필드 초기화
+      e.target.value = '';
+    } catch (error) {
+      console.error('이미지 처리 중 오류 발생:', error);
     }
   };
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -61,7 +61,7 @@ const GroupCreate = () => {
 
     const maxFileSizeMB = 5;
     if (file.size > maxFileSizeMB * 1024 * 1024) {
-      e.target.value = ''; // 파일 입력 필드 초기화
+      alert(`파일 크기가 ${maxFileSizeMB}MB를 초과했습니다.`);
       return;
     }
 
@@ -89,7 +89,7 @@ const GroupCreate = () => {
       // 파일 입력 필드 초기화
       e.target.value = '';
     } catch (error) {
-      console.error('이미지 처리 중 오류 발생:', error);
+      alert('이미지를 처리하는 도중 오류가 발생했습니다. 다시 시도해 주세요.');
     }
   };
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -1,3 +1,4 @@
+import imageCompression from 'browser-image-compression';
 import { useState } from 'react';
 import styled from 'styled-components';
 import CreateButton from '../components/GroupCreate/CreateButton';
@@ -54,18 +55,33 @@ const GroupCreate = () => {
     }
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files ? e.target.files[0] : null;
+    console.log(file);
+    // 이미지 압축 옵션 설정
+    const options = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 445,
+      useWebWorker: true, // Web Worker 사용
+    };
     if (file) {
-      // 선택된 파일을 상태로 저장
-      setSelctedImageFIle(file);
-      const reader = new FileReader();
-      reader.onload = () => {
-        setPreviewImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-      // 파일 입력 필드 초기화
-      e.target.value = '';
+      try {
+        // 이미지 압축 (비동기)
+        const compressedFile = await imageCompression(file, options);
+        setSelctedImageFIle(compressedFile);
+
+        // 미리보기 이미지 생성
+        const reader = new FileReader();
+        reader.onload = () => {
+          setPreviewImage(reader.result as string);
+        };
+        reader.readAsDataURL(compressedFile);
+
+        // 파일 입력 필드 초기화
+        e.target.value = '';
+      } catch (error) {
+        console.error('이미지 압축 중 오류 발생:', error);
+      }
     }
   };
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -66,8 +66,8 @@ const GroupCreate = () => {
     }
 
     const options = {
-      maxSizeMB: 0.5,
-      maxWidthOrHeight: 1224,
+      maxSizeMB: 0.2,
+      maxWidthOrHeight: 1226,
       useWebWorker: true,
     };
 

--- a/src/page/GroupCreate.tsx
+++ b/src/page/GroupCreate.tsx
@@ -60,8 +60,8 @@ const GroupCreate = () => {
     if (!file) return;
 
     const options = {
-      maxSizeMB: 1,
-      maxWidthOrHeight: 297,
+      maxSizeMB: 0.5,
+      maxWidthOrHeight: 1224,
       useWebWorker: true,
     };
 

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -80,8 +80,8 @@ const GroupEdit = () => {
     if (!file) return;
 
     const options = {
-      maxSizeMB: 1,
-      maxWidthOrHeight: 297,
+      maxSizeMB: 0.5,
+      maxWidthOrHeight: 1224,
       useWebWorker: true,
     };
 

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -79,6 +79,12 @@ const GroupEdit = () => {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    const maxFileSizeMB = 5;
+    if (file.size > maxFileSizeMB * 1024 * 1024) {
+      e.target.value = ''; // 파일 입력 필드 초기화
+      return;
+    }
+
     const options = {
       maxSizeMB: 0.5,
       maxWidthOrHeight: 1224,

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -81,7 +81,7 @@ const GroupEdit = () => {
 
     const maxFileSizeMB = 5;
     if (file.size > maxFileSizeMB * 1024 * 1024) {
-      e.target.value = ''; // 파일 입력 필드 초기화
+      alert(`파일 크기가 ${maxFileSizeMB}MB를 초과했습니다.`);
       return;
     }
 
@@ -109,7 +109,7 @@ const GroupEdit = () => {
       // 파일 입력 필드 초기화
       e.target.value = '';
     } catch (error) {
-      console.error('이미지 처리 중 오류 발생:', error);
+      alert('이미지를 처리하는 도중 오류가 발생했습니다. 다시 시도해 주세요.');
     }
   };
 

--- a/src/page/GroupEdit.tsx
+++ b/src/page/GroupEdit.tsx
@@ -86,8 +86,8 @@ const GroupEdit = () => {
     }
 
     const options = {
-      maxSizeMB: 0.5,
-      maxWidthOrHeight: 1224,
+      maxSizeMB: 0.2,
+      maxWidthOrHeight: 1226,
       useWebWorker: true,
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,13 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browserslist@^4.23.1:
   version "4.23.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.3.tgz#debb029d3c93ebc97ffbc8d9cbb03403e227c800"
@@ -2817,6 +2824,11 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 victory-vendor@^36.6.8:
   version "36.9.2"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #366 

## ✅ 작업 내용

- [x] 이미지 사이즈 크기 압축해서 업로드 될 수 있게 구현

## 📸 스크린샷 / GIF / Link
![스크린샷 2025-03-02 221715](https://github.com/user-attachments/assets/6653a23e-22c6-4e3d-a2e7-85ad336ec453)
![스크린샷 2025-03-02 221654](https://github.com/user-attachments/assets/d73c4e8f-cee4-462e-93b2-0ed133f90b11)

## 📌 이슈 사항
## 1️⃣ `browser-image-compression` 라이브러리 사용 이유
이미지를 압축하지 않고 원본 파일 그대로 업로드하는 방식으로 인해 이미지 로딩 속도가 저하 됐고 렌더링 시간이 증가하는 문제점을 발견했습니다. 위와 같은 문제를 해결하기 위해 클라에서 먼저 이미지를 압축한 후 업로드하는 방식으로 변경해서 구현했습니다.
## 2️⃣ 사용한 옵션 설명
```
const options = {
  maxSizeMB: 0.2, // 압축된 이미지의 최대 크기를 0.2MB로 제한
  maxWidthOrHeight: 1224, // 이미지의 최대 너비 또는 높이를 1224px로 제한
  useWebWorker: true, // 웹 워커를 사용하여 메인 스레드 성능 저하 방지
};
```
- maxSizeMB 0.2로 설정해준 이유는 게시글 이미지 권장 크기는 100~200KB라서 0.2로 설정해줬습니다.
- 처음에는 그룹 페이지에서 보여지는 이미지 크기( 297 × 178 px)를 기준으로 약 2배 크기인 594px로 설정하였습니다. 하지만, 그룹 정보 보기 뷰에서 해당 이미지를 표시할 때 해상도가 낮아져 이미지가 깨지는 문제가 발생하였습니다. 이를 해결하기 위해, 그룹 정보 보기 뷰에서 사용하는 이미지 크기( 612 × 368 px)를 기준으로 1224px로 설정해 줬습니다.
## 3️⃣ imageCompression 함수가 비동기 함수이므로 async/await 사용
```
const compressedBlob = await imageCompression(file, options);
      const compressedFile = new File([compressedBlob], file.name, {
        type: file.type,
        lastModified: Date.now(),
      });
```
imageCompression 함수는 비동기적으로 동작하므로, await 키워드를 사용해 압축이 완료될 때까지 기다린 후 compressedBlob에 결과를 저장합니다. 이후, new File([...])을 사용해 compressedBlob을 새로운 파일 객체로 변환했습니다. 
imageCompression 모듈을 이용하면 크기를 줄인 파일을 Blob 형태로 리턴해 줍니다. 저희는 File타입을 사용해야 하므로, 변환 코드를 추가해 줬습니다.
## 4️⃣ 이미지 파일 크기 제한
서버에서 10MB가 아닌 5MB로 제한을 두고 있었더라구요. 고민을 하다가 파일 크기가 너무 크면 아무리 압축을 해도 다른 파일보다 클 가능성이 높고, 굳이 그렇게 큰 이미지를 업로드할 필요가 없다고 생각해서 5MB로 변경했습니다! 5MB이상 이미지가 들어오면 제한하고 업로드를 중단하게 구현했습니다!
```
const maxFileSizeMB = 5;
if (file.size > maxFileSizeMB * 1024 * 1024) {
  e.target.value = ''; // 파일 입력 필드 초기화
  return;
}
```
## ✍ 궁금한 것
그룹 뷰 렌더링 크기 297 × 178 px 맞추는게 맞는건지 그룹 정보 보기 뷰 렌더링 크기 612 × 368 px 에 맞추는게 맞는건지 확신이 안듭니다. 그룹 뷰 이미지 로딩 속도 개선하려고 도입한건데 저기에 맞춰버리면 그룹 정보 보기 뷰 이미지가 너무 깨져 보여서...어떤 방향으로 가는게 맞을까요...? 
